### PR TITLE
feat: Phase 3 — implicit relevance feedback

### DIFF
--- a/mcp-server/serve.js
+++ b/mcp-server/serve.js
@@ -154,6 +154,17 @@ export function createAudreyServer(audrey, options = {}) {
           break;
         }
 
+        case 'POST /mark-used': {
+          const body = await parseBody(req);
+          if (!body.id) {
+            json(res, 400, { error: 'id is required' });
+            return;
+          }
+          ctx.audrey.markUsed(body.id);
+          json(res, 200, { ok: true });
+          break;
+        }
+
         case 'POST /forget': {
           const body = await parseBody(req);
           if (body.query) {
@@ -207,6 +218,7 @@ export function createAudreyServer(audrey, options = {}) {
             'POST /recall',
             'POST /dream',
             'POST /consolidate',
+            'POST /mark-used',
             'POST /forget',
             'POST /snapshot',
             'POST /restore',

--- a/src/audrey.js
+++ b/src/audrey.js
@@ -598,6 +598,20 @@ export class Audrey extends EventEmitter {
     return result;
   }
 
+  markUsed(id) {
+    const now = new Date().toISOString();
+    const tables = ['episodes', 'semantics', 'procedures'];
+    for (const table of tables) {
+      const result = this.db.prepare(
+        `UPDATE ${table} SET usage_count = usage_count + 1, last_used_at = ? WHERE id = ?`
+      ).run(now, id);
+      if (result.changes > 0) {
+        this.emit('used', { id, table, usageCount: result.changes });
+        return;
+      }
+    }
+  }
+
   async forgetByQuery(query, options = {}) {
     await this._ensureMigrated();
     const result = await forgetByQueryFn(this.db, this.embeddingProvider, query, options);

--- a/src/db.js
+++ b/src/db.js
@@ -249,7 +249,7 @@ function addColumnIfMissing(db, table, column, definition) {
   }
 }
 
-const SCHEMA_VERSION = 9;
+const SCHEMA_VERSION = 10;
 
 const MIGRATIONS = [
   { version: 1, up(db) { addColumnIfMissing(db, 'episodes', 'context', "TEXT DEFAULT '{}'"); } },
@@ -270,6 +270,14 @@ const MIGRATIONS = [
   { version: 9, up(db) {
     createFTSTables(db);
     backfillFTS(db);
+  }},
+  { version: 10, up(db) {
+    addColumnIfMissing(db, 'episodes', 'usage_count', 'INTEGER DEFAULT 0');
+    addColumnIfMissing(db, 'episodes', 'last_used_at', 'TEXT');
+    addColumnIfMissing(db, 'semantics', 'usage_count', 'INTEGER DEFAULT 0');
+    addColumnIfMissing(db, 'semantics', 'last_used_at', 'TEXT');
+    addColumnIfMissing(db, 'procedures', 'usage_count', 'INTEGER DEFAULT 0');
+    addColumnIfMissing(db, 'procedures', 'last_used_at', 'TEXT');
   }},
 ];
 

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -879,7 +879,7 @@ describe('MCP tool: memory_status', () => {
     expect(status.procedures).toBe(0);
     expect(status.vec_procedures).toBe(0);
     expect(status.dimensions).toBe(8);
-    expect(status.schema_version).toBe(9);
+    expect(status.schema_version).toBe(10);
     expect(status.healthy).toBe(true);
   });
 

--- a/tests/relevance.test.js
+++ b/tests/relevance.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Audrey } from '../src/index.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('implicit relevance feedback', () => {
+  let audrey;
+  let dataDir;
+  let memoryId;
+
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), 'audrey-relevance-'));
+    audrey = new Audrey({
+      dataDir,
+      agent: 'relevance-test',
+      embedding: { provider: 'mock', dimensions: 64 },
+    });
+    memoryId = await audrey.encode({
+      content: 'The deploy pipeline uses GitHub Actions with Node 20',
+      source: 'direct-observation',
+    });
+    // Encode a few more for recall coverage
+    await audrey.encode({ content: 'Redis SCAN is safer than KEYS for production', source: 'told-by-user' });
+    await audrey.encode({ content: 'Stripe webhook signature verification is required', source: 'direct-observation' });
+  });
+
+  afterAll(() => {
+    audrey.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('markUsed increments usage_count', () => {
+    const before = audrey.db.prepare('SELECT usage_count FROM episodes WHERE id = ?').get(memoryId);
+    expect(before.usage_count).toBe(0);
+
+    audrey.markUsed(memoryId);
+
+    const after = audrey.db.prepare('SELECT usage_count FROM episodes WHERE id = ?').get(memoryId);
+    expect(after.usage_count).toBe(1);
+  });
+
+  it('markUsed updates last_used_at', () => {
+    const before = audrey.db.prepare('SELECT last_used_at FROM episodes WHERE id = ?').get(memoryId);
+    // May already be set from previous test
+    audrey.markUsed(memoryId);
+    const after = audrey.db.prepare('SELECT last_used_at FROM episodes WHERE id = ?').get(memoryId);
+    expect(after.last_used_at).toBeDefined();
+    expect(after.last_used_at).not.toBeNull();
+  });
+
+  it('markUsed works on semantic memories too', async () => {
+    // Force consolidation to create a semantic
+    await audrey.encode({ content: 'Deploy pipeline uses GitHub Actions', source: 'direct-observation' });
+    await audrey.encode({ content: 'Deploy pipeline runs on GitHub Actions CI', source: 'direct-observation' });
+    await audrey.encode({ content: 'GitHub Actions handles the deploy pipeline', source: 'direct-observation' });
+    await audrey.consolidate({ similarityThreshold: -1, minClusterSize: 2 });
+    const sem = audrey.db.prepare('SELECT id, usage_count FROM semantics LIMIT 1').get();
+    if (sem) {
+      audrey.markUsed(sem.id);
+      const after = audrey.db.prepare('SELECT usage_count FROM semantics WHERE id = ?').get(sem.id);
+      expect(after.usage_count).toBe(1);
+    }
+  });
+
+  it('markUsed on nonexistent id does not throw', () => {
+    expect(() => audrey.markUsed('nonexistent-id')).not.toThrow();
+  });
+
+  it('emits used event', () => {
+    let emitted = false;
+    audrey.on('used', () => { emitted = true; });
+    audrey.markUsed(memoryId);
+    expect(emitted).toBe(true);
+  });
+
+  it('retrieved-but-never-used memories exist for dream to detect', async () => {
+    // Recall several times without marking used
+    for (let i = 0; i < 6; i++) {
+      await audrey.recall('Redis production');
+    }
+    // The Redis memory now has retrieval_count >= 6 but usage_count = 0
+    const redis = audrey.db.prepare(
+      "SELECT usage_count FROM episodes WHERE content LIKE '%Redis%'"
+    ).get();
+    expect(redis).toHaveProperty('usage_count');
+    expect(redis.usage_count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of the codex.md plan. Tracks which recalled memories actually get used, enabling self-improvement.

## What's new

- Migration 10: `usage_count` + `last_used_at` on episodes, semantics, procedures
- `markUsed(id)` method on Audrey class — increments count, emits 'used' event
- `POST /mark-used` REST endpoint
- Foundation for utility scoring in confidence calculation (next iteration)

## Research backing

MemRL (arXiv:2601.03192) proved tracking actual utility of recalled memories produces 56% improvement on sequential reasoning. This is the data collection layer.

## Test plan

- [x] 536 tests passing across 34 files (6 new, 0 regressions)
- [x] Benchmark gate: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)