### PR TITLE
fix: harden Audrey lifecycle and recall diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ const memories = await brain.recall('stripe rate limits', {
 const dream = await brain.dream();
 const briefing = await brain.greeting({ context: 'debugging stripe' });
 
+await brain.waitForIdle();
 brain.close();
 ```
 

--- a/docs/plans/roadmap-status-2026-03-29.md
+++ b/docs/plans/roadmap-status-2026-03-29.md
@@ -1,0 +1,47 @@
+# Audrey Roadmap Status - 2026-03-29
+
+This note replaces stale assumptions from the earlier `codex.md` roadmap with the current repo state.
+
+## Current State
+
+- Multi-agent memory is already shipped.
+- FTS-backed keyword search and hybrid retrieval are already shipped.
+- TypeScript declarations are already shipped.
+- REST API, dashboard, hooks integration, benchmarking, and CI are already shipped.
+
+The roadmap should no longer treat those as future phases. The highest-value work now is production correctness, operator clarity, and benchmark credibility.
+
+## Phase 0 Re-Evaluation
+
+Original bug list status:
+
+- `encode()` background work was tracked via `_pending`, but server and CLI shutdown paths still did not wait for that work to finish.
+- `importMemories` snapshot validation is already in place.
+- `recall()` degraded gracefully, but failure metadata was still too quiet for REST operators.
+- Consolidation no longer uses raw `BEGIN IMMEDIATE`; it already uses `better-sqlite3` transactions.
+- `parseBody` already guards against double-settle behavior.
+
+## This Pass
+
+- Added `Audrey.waitForIdle()` so production callers can drain tracked background work before shutdown or restore.
+- Updated REST restore and process shutdown flows to wait for idle work before closing the database.
+- Exposed `partialFailure` and `errors` on recall results and surfaced that metadata through the REST API.
+- Fixed FTS keyword-search agent attribution so keyword-only multi-agent recall preserves the correct agent namespace.
+- Added regression coverage for lifecycle draining, shutdown waiting, recall partial failures, and keyword-only multi-agent attribution.
+
+## Recommended Next Passes
+
+1. Clean the public docs and roadmap copy.
+   The current README and some planning docs still contain mojibake artifacts that hurt first contact.
+
+2. Make benchmark claims externally reproducible.
+   Add first-party LoCoMo and LongMemEval adapters under `memorybench` or fold them into this repo in a reproducible way.
+
+3. Tighten restore and import contracts.
+   Add explicit schema validation for snapshot versions and optional fields, then test malformed snapshots more aggressively.
+
+4. Improve operational visibility.
+   Add structured request logging and request IDs to the REST server, then expose recall failure counts in `/analytics`.
+
+5. Harden the SDK shutdown story.
+   Decide whether `close()` itself should eventually become async, or whether `waitForIdle()` remains the explicit graceful-shutdown contract.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -62,6 +62,7 @@ Guardrails:
 8. Keep API keys, bearer tokens, and raw credentials out of encoded memory content.
 9. Decide whether `private` memories are allowed for your use case and document who can create them.
 10. Add application-level encryption, access control, logging, and retention policies around Audrey.
+11. On graceful shutdown paths, call `await brain.waitForIdle()` before `brain.close()` so tracked background work drains cleanly.
 
 ## Operations Commands
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -49,6 +49,13 @@ export async function initializeEmbeddingProvider(provider) {
   }
 }
 
+async function closeAudreyGracefully(audrey) {
+  if (audrey && typeof audrey.waitForIdle === 'function') {
+    await audrey.waitForIdle();
+  }
+  audrey?.close();
+}
+
 export const memoryEncodeToolSchema = {
   content: z.string()
     .max(MAX_MEMORY_CONTENT_LENGTH)
@@ -122,7 +129,7 @@ async function reembed() {
     const counts = await reembedAll(audrey.db, audrey.embeddingProvider, { dropAndRecreate: dimensionsChanged });
     console.log(`Done. Re-embedded: ${counts.episodes} episodes, ${counts.semantics} semantics, ${counts.procedures} procedures`);
   } finally {
-    audrey.close();
+    await closeAudreyGracefully(audrey);
   }
 }
 
@@ -170,7 +177,7 @@ async function dream() {
     );
     console.log('[audrey] Dream complete.');
   } finally {
-    audrey.close();
+    await closeAudreyGracefully(audrey);
   }
 }
 
@@ -276,7 +283,7 @@ async function greeting() {
 
     console.log(lines.join('\n'));
   } finally {
-    audrey.close();
+    await closeAudreyGracefully(audrey);
   }
 }
 
@@ -352,7 +359,7 @@ async function reflect() {
     );
     console.log('[audrey] Dream complete.');
   } finally {
-    audrey.close();
+    await closeAudreyGracefully(audrey);
   }
 }
 
@@ -430,7 +437,7 @@ async function recall() {
 
     console.log(JSON.stringify(output));
   } finally {
-    audrey.close();
+    await closeAudreyGracefully(audrey);
   }
 }
 
@@ -622,7 +629,7 @@ async function snapshot() {
     console.log('');
     console.log('To restore: npx audrey restore ' + outputPath);
   } finally {
-    audrey.close();
+    await closeAudreyGracefully(audrey);
   }
 }
 
@@ -685,7 +692,7 @@ async function restore() {
     console.log(`[audrey] Restored: ${restored.episodic} episodes, ${restored.semantic} semantics, ${restored.procedural} procedures`);
     console.log('[audrey] Restore complete.');
   } finally {
-    audrey.close();
+    await closeAudreyGracefully(audrey);
   }
 }
 
@@ -937,6 +944,25 @@ export function registerShutdownHandlers(processRef, audrey, logger = console.er
     }
     if (!closed) {
       closed = true;
+      if (typeof audrey?.waitForIdle === 'function') {
+        Promise.resolve(audrey.waitForIdle())
+          .catch(err => {
+            logger(`[audrey-mcp] shutdown wait error: ${err.message || String(err)}`);
+            exitCode = exitCode === 0 ? 1 : exitCode;
+          })
+          .finally(() => {
+            try {
+              audrey.close();
+            } catch (err) {
+              logger(`[audrey-mcp] shutdown error: ${err.message || String(err)}`);
+              exitCode = exitCode === 0 ? 1 : exitCode;
+            }
+            if (typeof processRef.exit === 'function') {
+              processRef.exit(exitCode);
+            }
+          });
+        return;
+      }
       try {
         audrey.close();
       } catch (err) {

--- a/mcp-server/serve.js
+++ b/mcp-server/serve.js
@@ -214,6 +214,13 @@ function route(method, pathname) {
   return `${method} ${pathname}`;
 }
 
+async function drainAndCloseAudrey(audrey) {
+  if (audrey && typeof audrey.waitForIdle === 'function') {
+    await audrey.waitForIdle();
+  }
+  audrey?.close();
+}
+
 /**
  * Creates an HTTP server wrapping an Audrey instance.
  * @param {Audrey} audrey - The Audrey instance to serve
@@ -312,7 +319,11 @@ export function createAudreyServer(audrey, options = {}) {
           const { query, ...opts } = body;
           if (requestAgent) opts.agent = requestAgent;
           const results = await ctx.audrey.recall(query, opts);
-          json(res, 200, { results });
+          json(res, 200, {
+            results,
+            partialFailure: Boolean(results.partialFailure),
+            errors: results.errors ?? [],
+          });
           break;
         }
 
@@ -371,8 +382,8 @@ export function createAudreyServer(audrey, options = {}) {
             json(res, 501, { error: 'Restore not available: no audreyFactory configured' });
             return;
           }
-          ctx.audrey.close();
           const dbPath = ctx.audrey.db?.name;
+          await drainAndCloseAudrey(ctx.audrey);
           if (dbPath) {
             const dir = dirname(dbPath);
             for (const f of ['audrey.db', 'audrey.db-wal', 'audrey.db-shm']) {
@@ -456,9 +467,13 @@ export async function startServer(options = {}) {
 
   const shutdown = () => {
     console.log('\n[audrey] Shutting down...');
-    server._ctx.audrey.close();
-    server.close();
-    process.exit(0);
+    void drainAndCloseAudrey(server._ctx.audrey)
+      .catch(err => {
+        console.error('[audrey] Shutdown drain failed:', err.message);
+      })
+      .finally(() => {
+        server.close(() => process.exit(0));
+      });
   };
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);

--- a/src/audrey.js
+++ b/src/audrey.js
@@ -44,6 +44,7 @@ import { detectResonance } from './affect.js';
  * @property {string} [before]
  * @property {Record<string, string>} [context]
  * @property {{ valence?: number, arousal?: number }} [mood]
+ * @property {'hybrid' | 'vector' | 'keyword'} [retrieval]
  *
  * @typedef {Object} RecallResult
  * @property {string} id
@@ -168,6 +169,12 @@ export class Audrey extends EventEmitter {
   _trackAsync(promise) {
     this._pending.add(promise);
     promise.finally(() => this._pending.delete(promise));
+  }
+
+  async waitForIdle() {
+    while (this._pending.size > 0) {
+      await Promise.allSettled([...this._pending]);
+    }
   }
 
   _emitValidation(id, params) {

--- a/src/fts.js
+++ b/src/fts.js
@@ -55,7 +55,7 @@ export function searchFTSEpisodes(db, query, limit = 30, agentFilter = null) {
   const agentClause = agentFilter ? 'AND e.agent = ?' : '';
   const params = agentFilter ? [query, agentFilter, limit] : [query, limit];
   return db.prepare(`
-    SELECT f.id, f.content, bm25(fts_episodes) AS rank
+    SELECT f.id, f.content, e.agent, bm25(fts_episodes) AS rank
     FROM fts_episodes f
     JOIN episodes e ON e.id = f.id
     WHERE fts_episodes MATCH ?
@@ -70,7 +70,7 @@ export function searchFTSSemantics(db, query, limit = 30, agentFilter = null) {
   const agentClause = agentFilter ? 'AND s.agent = ?' : '';
   const params = agentFilter ? [query, agentFilter, limit] : [query, limit];
   return db.prepare(`
-    SELECT f.id, f.content, bm25(fts_semantics) AS rank
+    SELECT f.id, f.content, s.agent, bm25(fts_semantics) AS rank
     FROM fts_semantics f
     JOIN semantics s ON s.id = f.id
     WHERE fts_semantics MATCH ?
@@ -85,7 +85,7 @@ export function searchFTSProcedures(db, query, limit = 30, agentFilter = null) {
   const agentClause = agentFilter ? 'AND p.agent = ?' : '';
   const params = agentFilter ? [query, agentFilter, limit] : [query, limit];
   return db.prepare(`
-    SELECT f.id, f.content, bm25(fts_procedures) AS rank
+    SELECT f.id, f.content, p.agent, bm25(fts_procedures) AS rank
     FROM fts_procedures f
     JOIN procedures p ON p.id = f.id
     WHERE fts_procedures MATCH ?

--- a/src/recall.js
+++ b/src/recall.js
@@ -376,14 +376,7 @@ function knnProcedural(db, queryBuffer, candidateK, now, minConfidence, includeP
   return { results, matchedIds };
 }
 
-/**
- * @param {import('better-sqlite3').Database} db
- * @param {import('./embedding.js').EmbeddingProvider} embeddingProvider
- * @param {string} query
- * @param {{ minConfidence?: number, types?: string[], limit?: number, includeProvenance?: boolean, includeDormant?: boolean, tags?: string[], sources?: string[], after?: string, before?: string }} [options]
- * @returns {AsyncGenerator<{ id: string, content: string, type: string, confidence: number, score: number, source: string, createdAt: string }>}
- */
-export async function* recallStream(db, embeddingProvider, query, options = {}) {
+async function runRecallQuery(db, embeddingProvider, query, options = {}) {
   const {
     minConfidence = 0,
     types,
@@ -409,39 +402,39 @@ export async function* recallStream(db, embeddingProvider, query, options = {}) 
   if (retrieval === 'keyword') {
     const ftsAvailable = hasFTSTables(db);
     if (!ftsAvailable) {
-      return; // No FTS tables, no keyword results
+      return { top: [], errors: [] };
     }
     const sanitized = sanitizeFTSQuery(query);
-    if (!sanitized) return;
+    if (!sanitized) return { top: [], errors: [] };
 
     const keywordResults = [];
     try {
       if (searchTypes.includes('episodic')) {
         for (const row of searchFTSEpisodes(db, sanitized, limit * 3, agentFilter)) {
-          keywordResults.push({ id: row.id, content: row.content, type: 'episodic', score: -row.rank, agent: 'default' });
+          keywordResults.push({ id: row.id, content: row.content, type: 'episodic', score: -row.rank, agent: row.agent || 'default' });
         }
       }
       if (searchTypes.includes('semantic')) {
         for (const row of searchFTSSemantics(db, sanitized, limit * 3, agentFilter)) {
-          keywordResults.push({ id: row.id, content: row.content, type: 'semantic', score: -row.rank, agent: 'default' });
+          keywordResults.push({ id: row.id, content: row.content, type: 'semantic', score: -row.rank, agent: row.agent || 'default' });
         }
       }
       if (searchTypes.includes('procedural')) {
         for (const row of searchFTSProcedures(db, sanitized, limit * 3, agentFilter)) {
-          keywordResults.push({ id: row.id, content: row.content, type: 'procedural', score: -row.rank, agent: 'default' });
+          keywordResults.push({ id: row.id, content: row.content, type: 'procedural', score: -row.rank, agent: row.agent || 'default' });
         }
       }
     } catch {
       // FTS query syntax error — fall through with whatever we have
     }
     keywordResults.sort((a, b) => b.score - a.score);
-    for (const entry of keywordResults.slice(0, limit)) {
-      entry.confidence = 1;
-      entry.source = 'keyword';
-      entry.createdAt = now.toISOString();
-      yield entry;
-    }
-    return;
+    const top = keywordResults.slice(0, limit).map(entry => ({
+      ...entry,
+      confidence: 1,
+      source: 'keyword',
+      createdAt: now.toISOString(),
+    }));
+    return { top, errors: [] };
   }
 
   const queryVector = await embeddingProvider.embed(query);
@@ -546,6 +539,18 @@ export async function* recallStream(db, embeddingProvider, query, options = {}) 
   }
 
   const top = applyResultGuards(query, allResults, limit);
+  return { top, errors };
+}
+
+/**
+ * @param {import('better-sqlite3').Database} db
+ * @param {import('./embedding.js').EmbeddingProvider} embeddingProvider
+ * @param {string} query
+ * @param {{ minConfidence?: number, types?: string[], limit?: number, includeProvenance?: boolean, includeDormant?: boolean, tags?: string[], sources?: string[], after?: string, before?: string }} [options]
+ * @returns {AsyncGenerator<{ id: string, content: string, type: string, confidence: number, score: number, source: string, createdAt: string }>}
+ */
+export async function* recallStream(db, embeddingProvider, query, options = {}) {
+  const { top, errors } = await runRecallQuery(db, embeddingProvider, query, options);
   for (const entry of top) {
     if (errors.length > 0) entry._recallErrors = errors;
     yield entry;
@@ -560,9 +565,9 @@ export async function* recallStream(db, embeddingProvider, query, options = {}) 
  * @returns {Promise<Array<{ id: string, content: string, type: string, confidence: number, score: number, source: string, createdAt: string }>>}
  */
 export async function recall(db, embeddingProvider, query, options = {}) {
-  const results = [];
-  for await (const entry of recallStream(db, embeddingProvider, query, options)) {
-    results.push(entry);
-  }
+  const { top, errors } = await runRecallQuery(db, embeddingProvider, query, options);
+  const results = [...top];
+  results.partialFailure = errors.length > 0;
+  results.errors = errors;
   return results;
 }

--- a/tests/audrey.test.js
+++ b/tests/audrey.test.js
@@ -107,6 +107,24 @@ describe('Audrey', () => {
     expect(emitted).toBe(true);
   });
 
+  it('waitForIdle drains tracked background work', async () => {
+    let releasePending;
+    const pending = new Promise(resolve => {
+      releasePending = resolve;
+    });
+
+    brain._trackAsync(pending);
+    const wait = brain.waitForIdle();
+
+    await Promise.resolve();
+    expect(brain._pending.size).toBe(1);
+
+    releasePending();
+    await wait;
+
+    expect(brain._pending.size).toBe(0);
+  });
+
   it('runs consolidation', async () => {
     const result = await brain.consolidate();
     expect(result).toHaveProperty('runId');

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -261,6 +261,34 @@ describe('MCP lifecycle hardening', () => {
     expect(fakeProcess.exit).toHaveBeenCalledWith(0);
   });
 
+  it('waits for pending Audrey work before exiting when waitForIdle is available', async () => {
+    const fakeProcess = new EventEmitter();
+    fakeProcess.exit = vi.fn();
+
+    let releaseIdle;
+    const idle = new Promise(resolve => {
+      releaseIdle = resolve;
+    });
+    const audrey = {
+      waitForIdle: vi.fn(() => idle),
+      close: vi.fn(),
+    };
+
+    registerShutdownHandlers(fakeProcess, audrey, vi.fn());
+    fakeProcess.emit('SIGTERM');
+
+    expect(audrey.waitForIdle).toHaveBeenCalledOnce();
+    expect(audrey.close).not.toHaveBeenCalled();
+    expect(fakeProcess.exit).not.toHaveBeenCalled();
+
+    releaseIdle();
+    await idle;
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(audrey.close).toHaveBeenCalledOnce();
+    expect(fakeProcess.exit).toHaveBeenCalledWith(0);
+  });
+
   it('exits non-zero on unhandled rejections', () => {
     const fakeProcess = new EventEmitter();
     fakeProcess.exit = vi.fn();

--- a/tests/multi-agent.test.js
+++ b/tests/multi-agent.test.js
@@ -77,4 +77,17 @@ describe('multi-agent memory', () => {
     expect(results.length).toBe(0);
     audreyC.close();
   });
+
+  it('keyword-only recall preserves agent attribution', async () => {
+    const results = await audreyA.recall('Alpha', {
+      limit: 10,
+      scope: 'agent',
+      retrieval: 'keyword',
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    for (const result of results) {
+      expect(result.agent).toBe('agent-alpha');
+    }
+  });
 });

--- a/tests/recall.test.js
+++ b/tests/recall.test.js
@@ -198,6 +198,18 @@ describe('recall', () => {
     expect(incremented).toBe(true);
   });
 
+  it('surfaces partial failures when a recall path breaks', async () => {
+    db.exec('DROP TABLE vec_semantics');
+
+    const results = await recall(db, embedding, 'Stripe rate limit', { types: ['semantic'] });
+
+    expect(results).toHaveLength(0);
+    expect(results.partialFailure).toBe(true);
+    expect(results.errors).toEqual([
+      expect.objectContaining({ type: 'semantic' }),
+    ]);
+  });
+
   // --- recallStream tests ---
 
   it('recallStream yields results as async generator', async () => {

--- a/tests/serve.test.js
+++ b/tests/serve.test.js
@@ -132,6 +132,37 @@ describe('Audrey REST API Server', () => {
     expect(res.data.error).toContain('query');
   });
 
+  it('POST /recall reports partial failures when a search path is unavailable', async () => {
+    const brokenDataDir = mkdtempSync(join(tmpdir(), 'audrey-serve-partial-'));
+    const brokenAudrey = new Audrey({
+      dataDir: brokenDataDir,
+      agent: 'test-partial',
+      embedding: { provider: 'mock', dimensions: 64 },
+    });
+    const brokenServer = createAudreyServer(brokenAudrey);
+    await new Promise(resolve => brokenServer.listen(0, '127.0.0.1', resolve));
+
+    try {
+      brokenAudrey.db.exec('DROP TABLE vec_semantics');
+
+      const res = await request(brokenServer, 'POST', '/recall', {
+        query: 'server test memory',
+        types: ['semantic'],
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.data.results).toEqual([]);
+      expect(res.data.partialFailure).toBe(true);
+      expect(res.data.errors).toEqual([
+        expect.objectContaining({ type: 'semantic' }),
+      ]);
+    } finally {
+      brokenServer.close();
+      brokenAudrey.close();
+      rmSync(brokenDataDir, { recursive: true, force: true });
+    }
+  });
+
   it('POST /dream runs consolidation cycle', async () => {
     const res = await request(server, 'POST', '/dream', {});
     expect(res.status).toBe(200);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -120,6 +120,7 @@ export interface RecallOptions {
   affect?: AffectParams;
   scope?: 'shared' | 'agent';
   agent?: string;
+  retrieval?: 'hybrid' | 'vector' | 'keyword';
 }
 
 export interface RecallResult {
@@ -142,6 +143,11 @@ export interface RecallResult {
   };
   _recallErrors?: Array<{ type: string; message: string }>;
 }
+
+export type RecallResults = RecallResult[] & {
+  partialFailure?: boolean;
+  errors?: Array<{ type: string; message: string }>;
+};
 
 // === Consolidation ===
 
@@ -344,7 +350,7 @@ export class Audrey extends EventEmitter {
   constructor(config: AudreyConfig);
 
   encode(params: EncodeParams): Promise<string>;
-  recall(query: string, options?: RecallOptions): Promise<RecallResult[]>;
+  recall(query: string, options?: RecallOptions): Promise<RecallResults>;
   recallStream(query: string, options?: RecallOptions): AsyncGenerator<RecallResult>;
   consolidate(options?: ConsolidateOptions): Promise<ConsolidationResult>;
   dream(options?: DreamOptions): Promise<DreamResult>;
@@ -358,6 +364,7 @@ export class Audrey extends EventEmitter {
   reflect(turns: string): Promise<ReflectResult>;
   startAutoConsolidate(intervalMs: number, options?: ConsolidateOptions): void;
   stopAutoConsolidate(): void;
+  waitForIdle(): Promise<void>;
   close(): void;
 }
 
@@ -369,7 +376,7 @@ export function readStoredDimensions(dataDir: string): number | null;
 
 // === Standalone Functions ===
 
-export function recall(db: Database, embeddingProvider: EmbeddingProvider, query: string, options?: RecallOptions): Promise<RecallResult[]>;
+export function recall(db: Database, embeddingProvider: EmbeddingProvider, query: string, options?: RecallOptions): Promise<RecallResults>;
 export function recallStream(db: Database, embeddingProvider: EmbeddingProvider, query: string, options?: RecallOptions): AsyncGenerator<RecallResult>;
 export function exportMemories(db: Database): Snapshot;
 export function importMemories(db: Database, embeddingProvider: EmbeddingProvider, snapshot: Snapshot): Promise<void>;


### PR DESCRIPTION
## Summary
- add graceful idle-drain support for CLI, REST restore, and shutdown paths
- expose recall partial-failure metadata and fix keyword-only agent attribution
- add regression coverage and a roadmap status note for the current Audrey state

## Validation
- full suite: 541 passed, 6 skipped via sandbox-safe Vitest invocation
- npm pack --dry-run passed using a repo-local npm cache
