### PR TITLE
fix: CodeRabbit follow-ups (migrate batching, recallStream agent, install device)

### DIFF
--- a/scripts/install-audrey-machine.ps1
+++ b/scripts/install-audrey-machine.ps1
@@ -2,7 +2,9 @@
 param(
   [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path,
   [string]$NodeExe = 'C:\Program Files\nodejs\node.exe',
-  [string]$DataDir = "$env:USERPROFILE\.audrey\data"
+  [string]$DataDir = "$env:USERPROFILE\.audrey\data",
+  [ValidateSet('cpu', 'gpu')]
+  [string]$Device = 'cpu'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -41,7 +43,8 @@ function Update-JsonMcpEntryWithNode {
     [Parameter(Mandatory = $true)][string]$Entry,
     [Parameter(Mandatory = $true)][string]$Node,
     [Parameter(Mandatory = $true)][string]$StoreDir,
-    [Parameter(Mandatory = $true)][string]$Agent
+    [Parameter(Mandatory = $true)][string]$Agent,
+    [Parameter(Mandatory = $true)][string]$Device
   )
 
   $parent = Split-Path -Parent $Path
@@ -51,7 +54,7 @@ function Update-JsonMcpEntryWithNode {
 
   $patchScript = @'
 import fs from "node:fs";
-const [path, entry, storeDir, agent, nodeExe] = process.argv.slice(2);
+const [path, entry, storeDir, agent, nodeExe, device] = process.argv.slice(2);
 let config = {};
 if (fs.existsSync(path)) {
   config = JSON.parse(fs.readFileSync(path, "utf8"));
@@ -67,7 +70,7 @@ config.mcpServers["audrey-memory"] = {
     AUDREY_DATA_DIR: storeDir,
     AUDREY_AGENT: agent,
     AUDREY_EMBEDDING_PROVIDER: "local",
-    AUDREY_DEVICE: "gpu"
+    AUDREY_DEVICE: device
   }
 };
 fs.writeFileSync(path, JSON.stringify(config, null, 2));
@@ -78,7 +81,7 @@ fs.writeFileSync(path, JSON.stringify(config, null, 2));
   Set-Content -LiteralPath $scriptFile -Value $patchScript -Encoding utf8
 
   try {
-    & $Node $scriptFile $Path $Entry $StoreDir $Agent $Node
+    & $Node $scriptFile $Path $Entry $StoreDir $Agent $Node $Device
   } finally {
     Remove-Item -LiteralPath $scriptFile -Force -ErrorAction SilentlyContinue
   }
@@ -89,12 +92,13 @@ function Update-ClaudeCodeConfig {
     [string]$Path,
     [string]$Entry,
     [string]$Node,
-    [string]$StoreDir
+    [string]$StoreDir,
+    [string]$Device
   )
 
   if ($PSCmdlet.ShouldProcess($Path, 'Update Claude Code Audrey MCP entry')) {
     Backup-File -Path $Path
-    Update-JsonMcpEntryWithNode -Path $Path -Entry $Entry -Node $Node -StoreDir $StoreDir -Agent 'claude-code'
+    Update-JsonMcpEntryWithNode -Path $Path -Entry $Entry -Node $Node -StoreDir $StoreDir -Agent 'claude-code' -Device $Device
   }
 }
 
@@ -103,12 +107,13 @@ function Update-ClaudeDesktopConfig {
     [string]$Path,
     [string]$Entry,
     [string]$Node,
-    [string]$StoreDir
+    [string]$StoreDir,
+    [string]$Device
   )
 
   if ($PSCmdlet.ShouldProcess($Path, 'Update Claude Desktop Audrey MCP entry')) {
     Backup-File -Path $Path
-    Update-JsonMcpEntryWithNode -Path $Path -Entry $Entry -Node $Node -StoreDir $StoreDir -Agent 'claude-desktop'
+    Update-JsonMcpEntryWithNode -Path $Path -Entry $Entry -Node $Node -StoreDir $StoreDir -Agent 'claude-desktop' -Device $Device
   }
 }
 
@@ -117,7 +122,8 @@ function Update-CodexConfig {
     [string]$Path,
     [string]$Entry,
     [string]$Node,
-    [string]$StoreDir
+    [string]$StoreDir,
+    [string]$Device
   )
 
   $existingLines = if (Test-Path $Path) {
@@ -163,7 +169,7 @@ function Update-CodexConfig {
     "AUDREY_DATA_DIR = '$StoreDir'",
     "AUDREY_AGENT = 'codex'",
     "AUDREY_EMBEDDING_PROVIDER = 'local'",
-    "AUDREY_DEVICE = 'gpu'"
+    "AUDREY_DEVICE = '$Device'"
   )
 
   $finalLines = New-Object 'System.Collections.Generic.List[string]'
@@ -201,10 +207,11 @@ function Update-CodexConfig {
 Write-Host "Repo root: $RepoRoot"
 Write-Host "Audrey entrypoint: $audreyEntry"
 Write-Host "Data dir: $DataDir"
+Write-Host "Embedding device: $Device"
 
-Update-CodexConfig -Path $codexConfigPath -Entry $audreyEntry -Node $NodeExe -StoreDir $DataDir
-Update-ClaudeCodeConfig -Path $claudeCodeConfigPath -Entry $audreyEntry -Node $NodeExe -StoreDir $DataDir
-Update-ClaudeDesktopConfig -Path $claudeDesktopConfigPath -Entry $audreyEntry -Node $NodeExe -StoreDir $DataDir
+Update-CodexConfig -Path $codexConfigPath -Entry $audreyEntry -Node $NodeExe -StoreDir $DataDir -Device $Device
+Update-ClaudeCodeConfig -Path $claudeCodeConfigPath -Entry $audreyEntry -Node $NodeExe -StoreDir $DataDir -Device $Device
+Update-ClaudeDesktopConfig -Path $claudeDesktopConfigPath -Entry $audreyEntry -Node $NodeExe -StoreDir $DataDir -Device $Device
 
 Write-Host ''
 Write-Host 'ChatGPT note: custom MCP currently requires a remote MCP server over streaming HTTP or SSE.'

--- a/src/audrey.ts
+++ b/src/audrey.ts
@@ -644,7 +644,7 @@ export class Audrey extends EventEmitter {
     await this._ensureMigrated();
     yield* recallStreamFn(this.db, this.embeddingProvider, query, {
       ...options,
-      agent: this.agent,
+      agent: options.agent ?? this.agent,
       retrieval: options.retrieval ?? this.defaultRetrievalMode,
       confidenceConfig: this._recallConfig(options),
     });

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -6,7 +6,31 @@ interface EpisodeMigrateRow {
   id: string;
   content: string;
   source: string;
-  consolidated: number;
+  consolidated: number | null;
+}
+
+const REEMBED_BATCH_SIZE = 256;
+
+async function embedInChunks(
+  embeddingProvider: EmbeddingProvider,
+  contents: string[],
+  label: string,
+): Promise<number[][]> {
+  if (contents.length === 0) return [];
+  const out: number[][] = [];
+  for (let i = 0; i < contents.length; i += REEMBED_BATCH_SIZE) {
+    const slice = contents.slice(i, i + REEMBED_BATCH_SIZE);
+    try {
+      const vectors = await embeddingProvider.embedBatch(slice);
+      out.push(...vectors);
+    } catch (err) {
+      const cause = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `reembedAll: embedBatch failed for ${label} (rows ${i}-${i + slice.length - 1}): ${cause}`,
+      );
+    }
+  }
+  return out;
 }
 
 interface SemanticMigrateRow {
@@ -35,15 +59,21 @@ export async function reembedAll(
   const semantics = db.prepare('SELECT id, content, state FROM semantics').all() as SemanticMigrateRow[];
   const procedures = db.prepare('SELECT id, content, state FROM procedures').all() as ProcedureMigrateRow[];
 
-  const episodeVectors = episodes.length > 0
-    ? await embeddingProvider.embedBatch(episodes.map(ep => ep.content))
-    : [];
-  const semanticVectors = semantics.length > 0
-    ? await embeddingProvider.embedBatch(semantics.map(s => s.content))
-    : [];
-  const procedureVectors = procedures.length > 0
-    ? await embeddingProvider.embedBatch(procedures.map(p => p.content))
-    : [];
+  const episodeVectors = await embedInChunks(
+    embeddingProvider,
+    episodes.map(ep => ep.content),
+    'episodes',
+  );
+  const semanticVectors = await embedInChunks(
+    embeddingProvider,
+    semantics.map(s => s.content),
+    'semantics',
+  );
+  const procedureVectors = await embedInChunks(
+    embeddingProvider,
+    procedures.map(p => p.content),
+    'procedures',
+  );
 
   const updateEpLegacy = db.prepare('UPDATE episodes SET embedding = ? WHERE id = ?');
   const deleteVecEp = db.prepare('DELETE FROM vec_episodes WHERE id = ?');


### PR DESCRIPTION
## Summary

Picks up the deferred CodeRabbit findings from PR #20.

- **`src/migrate.ts`** — `reembedAll` now chunks `embedBatch` calls into 256-row batches and labels failures by kind + row range, so a partial embed failure on a 50K-episode reembed doesn't print a bare provider error and lose the location. Type fix on `EpisodeMigrateRow.consolidated` (was `number`, runtime used `?? 0`).
- **`src/audrey.ts`** — `recallStream` now respects `options.agent`, matching the non-streaming path. Pre-fix it always used `this.agent` and silently ignored the override.
- **`scripts/install-audrey-machine.ps1`** — new `$Device` parameter (`cpu`|`gpu`, default `cpu`) threaded through `Update-JsonMcpEntryWithNode`, `Update-ClaudeCodeConfig`, `Update-ClaudeDesktopConfig`, and `Update-CodexConfig`. Pre-fix it hardcoded `AUDREY_DEVICE='gpu'` and broke fresh installs on machines without a CUDA-capable GPU.

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run` — 651 passed / 14 skipped / 0 failed
- [ ] Manual `install-audrey-machine.ps1` smoke (run on a Windows host with `-Device cpu`)