### PR TITLE
Release Audrey Guard 0.23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Core sidecar tools:
 
 | Agent Need | REST Route |
 |---|---|
+| Guard an action before tool use | `POST /v1/guard/before` |
+| Record the outcome after tool use | `POST /v1/guard/after` |
 | Check memory before acting | `POST /v1/preflight` |
 | Get reflex rules for an action | `POST /v1/reflexes` |
 | Store a useful observation | `POST /v1/encode` |
@@ -112,18 +114,33 @@ Core sidecar tools:
 | Get a turn-sized memory packet | `POST /v1/capsule` |
 | Check health | `GET /v1/status` |
 
+## Audrey Guard
+
+Audrey Guard is the memory-before-action loop. It asks Audrey what matters before a tool runs, returns a receipt-backed `go`, `caution`, or `block` decision, and records the outcome afterward so memory quality improves over time.
+
+```bash
+npx audrey guard --tool "npm test" --strict "run npm test before release"
+npx audrey guard --json --tool "npm test" --strict "run npm test before release"
+```
+
+Agents and hooks should pair `guard` with `guard-after`:
+
+```bash
+npx audrey guard-after --receipt <receipt_id> --outcome failed --error-summary "Vitest failed with spawn EPERM"
+```
+
 ## What Ships
 
 | Surface | Status |
 |---|---|
-| MCP stdio server | 20 tools plus status/recent/principles resources and briefing/recall/reflection prompts |
-| CLI | `doctor`, `demo`, `install`, `mcp-config`, `status`, `dream`, `reembed`, `observe-tool`, `promote`, `impact` |
+| MCP stdio server | 22 tools plus status/recent/principles resources and briefing/recall/reflection prompts |
+| CLI | `doctor`, `demo`, `guard`, `guard-after`, `install`, `mcp-config`, `status`, `dream`, `reembed`, `observe-tool`, `promote`, `impact` |
 | REST API | Hono server with `/health` and `/v1/*` routes |
 | JavaScript SDK | Direct TypeScript/Node import from `audrey` |
 | Python client | `pip install audrey-memory`, calls the REST sidecar |
 | Storage | Local SQLite plus `sqlite-vec`, no hosted database required |
 | Deployment | npm package, Docker, Compose, host-specific MCP config generation |
-| Safety loop | preflight warnings, reflexes, redacted tool traces, contradiction handling |
+| Safety loop | guard receipts, preflight warnings, reflexes, redacted tool traces, contradiction handling |
 
 ## Memory Model
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Production controls you still own:
 
 ## Benchmarks
 
-Audrey ships two benchmark commands.
+Audrey ships benchmark commands for performance, memory behavior, and the guard loop.
 
 ### Performance snapshot
 
@@ -274,11 +274,12 @@ These numbers cover Audrey's own pipeline (SQLite + sqlite-vec + hybrid ranking)
 
 ### Behavioral regression suite
 
-`npm run bench:memory:check` is a release gate. It runs a small set of retrieval and lifecycle scenarios (information extraction, knowledge updates, multi-session reasoning, conflict resolution, privacy boundary, overwrite, delete-and-abstain, semantic/procedural merge) against Audrey and three weak baselines (vector-only, keyword+recency, recent-window) and asserts Audrey doesn't regress. The baseline comparisons exist to catch correctness regressions in retrieval logic, not to make marketing claims.
+`npm run bench:memory:check` is a release gate. It runs a small set of retrieval, lifecycle, and guard-loop scenarios (information extraction, knowledge updates, multi-session reasoning, conflict resolution, privacy boundary, overwrite, delete-and-abstain, semantic/procedural merge, prior tool-failure caution, and strict must-follow blocking) and asserts Audrey doesn't regress. Retrieval and lifecycle cases compare Audrey with three weak baselines (vector-only, keyword+recency, recent-window). Guard-loop cases are reported as a controller regression suite against no-controller placeholders, not as a fair baseline leaderboard.
 
 ```bash
 npm run bench:memory          # full regression suite (writes JSON + report)
 npm run bench:memory:check    # release gate, exits non-zero on regression
+npm run bench:memory:guard    # closed-loop guard benchmark only
 ```
 
 ## Command Reference

--- a/benchmarks/cases.js
+++ b/benchmarks/cases.js
@@ -388,6 +388,53 @@ export const OPERATION_CASES = [
   },
 ];
 
+export const GUARD_CASES = [
+  {
+    id: 'guard-recent-tool-failure',
+    suite: 'guard',
+    kind: 'guard',
+    family: 'closed_loop_failure_memory',
+    title: 'Guard remembers failed tool outcome',
+    description: 'A failed guarded tool run should create a future caution and warning reflex for the same tool.',
+    action: 'run npm test before release',
+    tool: 'npm test',
+    expectAll: ['decision:caution', 'warning:recent_failure', 'reflex:warn'],
+    forbid: ['decision:go'],
+    steps: [
+      {
+        type: 'guardCycle',
+        action: 'run npm test',
+        tool: 'npm test',
+        outcome: 'failed',
+        errorSummary: 'Vitest failed with spawn EPERM',
+      },
+    ],
+  },
+  {
+    id: 'guard-strict-must-follow',
+    suite: 'guard',
+    kind: 'guard',
+    family: 'strict_must_follow_block',
+    title: 'Guard blocks strict must-follow release memory',
+    description: 'Strict guard mode should block a release action when must-follow memory applies.',
+    action: 'publish Audrey release',
+    tool: 'npm publish',
+    strict: true,
+    expectAll: ['decision:block', 'warning:must_follow', 'reflex:block'],
+    forbid: ['decision:go'],
+    steps: [
+      {
+        type: 'encode',
+        memory: {
+          content: 'Never publish Audrey without running npm pack --dry-run first.',
+          source: 'direct-observation',
+          tags: ['must-follow', 'release'],
+        },
+      },
+    ],
+  },
+];
+
 export const LOCAL_BENCHMARK_SUITES = [
   {
     id: 'retrieval',
@@ -400,6 +447,13 @@ export const LOCAL_BENCHMARK_SUITES = [
     title: 'Memory operations',
     description: 'Update, delete, merge, and abstention behavior after lifecycle operations.',
     cases: OPERATION_CASES,
+  },
+  {
+    id: 'guard',
+    title: 'Agent guard loop',
+    description: 'Closed-loop memory-before-action behavior for receipts, warnings, and blocking reflexes.',
+    comparableToBaselines: false,
+    cases: GUARD_CASES,
   },
 ];
 
@@ -418,4 +472,6 @@ export const FAMILY_ORDER = [
   'delete_and_abstain',
   'semantic_merge',
   'procedural_merge',
+  'closed_loop_failure_memory',
+  'strict_must_follow_block',
 ];

--- a/benchmarks/report.js
+++ b/benchmarks/report.js
@@ -114,8 +114,11 @@ export function writeBenchmarkArtifacts({
 }) {
   mkdirSync(outputDir, { recursive: true });
 
+  const localChartTitle = summary.local?.overall_scope === 'comparable_suites'
+    ? 'Audrey vs Comparable Local Memory Baselines'
+    : 'Selected Audrey Regression Suite';
   const localChart = renderBarChart({
-    title: 'Audrey vs Local Memory Baselines',
+    title: localChartTitle,
     rows: localOverall.map(row => ({ label: row.system, value: row.scorePercent })),
   });
   const externalChart = renderBarChart({
@@ -196,7 +199,7 @@ export function writeBenchmarkArtifacts({
   <main>
     <h1>Audrey Memory Benchmark</h1>
     <div class="callout">
-      <p><strong>Method:</strong> Audrey is scored on a LongMemEval-inspired retrieval benchmark plus an operation-level lifecycle benchmark. The report still separates local Audrey-versus-baseline results from published external LoCoMo numbers so the comparison stays honest.</p>
+      <p><strong>Method:</strong> Audrey is scored on a LongMemEval-inspired retrieval benchmark, an operation-level lifecycle benchmark, and an agent guard-loop benchmark. The combined local chart uses comparable retrieval/lifecycle suites when available; the guard loop is reported as its own controller regression suite. Published external LoCoMo numbers stay separate so the comparison remains honest.</p>
       <p><strong>Run:</strong> <code>${escapeHtml(summary.command)}</code></p>
       <p><strong>Generated:</strong> ${escapeHtml(summary.generatedAt)}</p>
     </div>

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -92,12 +92,15 @@ function summarizeResults(results) {
 function evaluateCase(benchmarkCase, results) {
   const normalizedContents = results.map(result => normalize(result.content));
   const expected = (benchmarkCase.expectAny || []).map(normalize);
+  const required = (benchmarkCase.expectAll || []).map(normalize);
   const forbidden = (benchmarkCase.forbid || []).map(normalize);
   const firstMatchIndex = expected.length === 0
     ? -1
     : normalizedContents.findIndex(content => expected.some(expectation => content.includes(expectation)));
   const firstForbiddenIndex = normalizedContents.findIndex(content => forbidden.some(blocked => content.includes(blocked)));
   const matched = firstMatchIndex !== -1;
+  const requiredMatches = required.filter(expectation => normalizedContents.some(content => content.includes(expectation)));
+  const matchedRequired = required.length > 0 && requiredMatches.length === required.length;
   const leakedForbidden = firstForbiddenIndex !== -1;
 
   if (benchmarkCase.expectNone) {
@@ -106,6 +109,24 @@ function evaluateCase(benchmarkCase, results) {
       passed: score === 1,
       score,
       summary: leakedForbidden ? 'leaked restricted content' : results.length === 0 ? 'correct abstention' : 'no leak, but retrieved tangential context',
+    };
+  }
+
+  if (required.length > 0) {
+    const score = matchedRequired && !leakedForbidden
+      ? 1
+      : leakedForbidden
+        ? 0
+        : Math.min(0.5, requiredMatches.length / required.length);
+    const missing = required.filter(expectation => !requiredMatches.includes(expectation));
+    return {
+      passed: score === 1,
+      score,
+      summary: matchedRequired
+        ? 'matched all required signals'
+        : missing.length > 0
+          ? `missed required signal${missing.length === 1 ? '' : 's'}: ${missing.join(', ')}`
+          : 'blocked content outranked the required signals',
     };
   }
 
@@ -201,6 +222,69 @@ async function seedOperationsCase(brain, benchmarkCase) {
   }
 }
 
+async function executeGuardStep(brain, step, refs) {
+  if (step.type === 'encode' || step.type === 'forgetByQuery' || step.type === 'consolidate') {
+    await executeAudreyStep(brain, step, refs);
+    return;
+  }
+
+  if (step.type === 'guardCycle') {
+    const before = await brain.beforeAction(step.action, {
+      tool: step.tool,
+      strict: Boolean(step.strict),
+      includeCapsule: step.includeCapsule ?? false,
+    });
+    if (step.saveReceiptAs) {
+      refs.set(step.saveReceiptAs, before.receipt_id);
+    }
+    brain.afterAction({
+      receiptId: before.receipt_id,
+      tool: step.tool,
+      outcome: step.outcome ?? 'unknown',
+      errorSummary: step.errorSummary,
+    });
+    return;
+  }
+
+  throw new Error(`Unsupported guard benchmark step: ${step.type}`);
+}
+
+async function seedGuardCase(brain, benchmarkCase) {
+  const refs = new Map();
+  for (const step of benchmarkCase.steps || []) {
+    await executeGuardStep(brain, step, refs);
+  }
+}
+
+function guardDecisionRows(decision) {
+  const rows = [{
+    id: decision.receipt_id,
+    content: `decision:${decision.decision} verdict:${decision.verdict} risk:${decision.risk_score} ${decision.summary}`,
+    type: 'guard_decision',
+    score: 1,
+  }];
+
+  for (const [index, warning] of decision.warnings.entries()) {
+    rows.push({
+      id: warning.evidence_id || `${decision.receipt_id}:warning:${index}`,
+      content: `warning:${warning.type} severity:${warning.severity} ${warning.message} ${warning.recommended_action || ''}`,
+      type: 'guard_warning',
+      score: 0.95 - index * 0.01,
+    });
+  }
+
+  for (const [index, reflex] of decision.reflexes.entries()) {
+    rows.push({
+      id: reflex.id || `${decision.receipt_id}:reflex:${index}`,
+      content: `reflex:${reflex.response_type} source:${reflex.source} severity:${reflex.severity} ${reflex.response}`,
+      type: 'guard_reflex',
+      score: 0.85 - index * 0.01,
+    });
+  }
+
+  return rows;
+}
+
 async function runAudreyCase(benchmarkCase, providerConfig) {
   const tempRoot = resolve('benchmarks/.tmp');
   mkdirSync(tempRoot, { recursive: true });
@@ -218,11 +302,22 @@ async function runAudreyCase(benchmarkCase, providerConfig) {
 
     if (benchmarkCase.kind === 'operations') {
       await seedOperationsCase(brain, benchmarkCase);
+    } else if (benchmarkCase.kind === 'guard') {
+      await seedGuardCase(brain, benchmarkCase);
     } else {
       await seedRetrievalCase(brain, benchmarkCase);
     }
 
     await brain.waitForIdle();
+    if (benchmarkCase.kind === 'guard') {
+      const decision = await brain.beforeAction(benchmarkCase.action, {
+        tool: benchmarkCase.tool,
+        strict: Boolean(benchmarkCase.strict),
+        includeCapsule: benchmarkCase.includeCapsule ?? false,
+      });
+      return guardDecisionRows(decision);
+    }
+
     return await brain.recall(benchmarkCase.query, {
       limit: 5,
       minConfidence: 0.05,
@@ -235,6 +330,15 @@ async function runAudreyCase(benchmarkCase, providerConfig) {
 }
 
 async function runBaselineCase(system, benchmarkCase, providerConfig) {
+  if (benchmarkCase.kind === 'guard') {
+    return [{
+      id: `${system.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-guard-baseline`,
+      content: 'decision:go verdict:clear summary:retrieval-only baseline has no before-action guard controller',
+      type: 'guard_decision',
+      score: 0,
+    }];
+  }
+
   return runBaselineScenario(system, benchmarkCase, providerConfig, 5);
 }
 
@@ -320,6 +424,7 @@ function summarizeSuites(caseResults, suites) {
       id: suite.id,
       title: suite.title,
       description: suite.description,
+      comparableToBaselines: suite.comparableToBaselines !== false,
       overall: summarizeLocalResults(suiteCases),
       byFamily: summarizeByFamily(suiteCases),
       cases: suiteCases,
@@ -401,13 +506,20 @@ export async function runBenchmarkSuite(options = {}) {
         family: benchmarkCase.family,
         description: benchmarkCase.description,
         query: benchmarkCase.query,
+        action: benchmarkCase.action,
+        tool: benchmarkCase.tool,
+        comparable_to_baselines: suite.comparableToBaselines !== false,
         results,
       });
     }
   }
 
-  const localOverall = summarizeLocalResults(caseResults);
-  const localByFamily = summarizeByFamily(caseResults);
+  const comparableCaseResults = caseResults.filter(caseResult => caseResult.comparable_to_baselines);
+  const overallCaseResults = comparableCaseResults.length > 0 ? comparableCaseResults : caseResults;
+  const overallScope = comparableCaseResults.length > 0 ? 'comparable_suites' : 'selected_suites';
+  const overallSuiteIds = [...new Set(overallCaseResults.map(caseResult => caseResult.suite))];
+  const localOverall = summarizeLocalResults(overallCaseResults);
+  const localByFamily = summarizeByFamily(overallCaseResults);
   const localSuites = summarizeSuites(caseResults, selectedSuites);
 
   return {
@@ -418,13 +530,16 @@ export async function runBenchmarkSuite(options = {}) {
       suites: suiteIds,
     },
     methodology: {
-      localBenchmark: 'LongMemEval-inspired retrieval benchmark plus operation-level lifecycle benchmark',
+      localBenchmark: 'LongMemEval-inspired retrieval benchmark plus operation-level lifecycle and agent guard-loop benchmarks',
       retrievalBenchmark: 'Information extraction, updates, reasoning, procedural learning, privacy, abstention, and conflict handling',
       operationsBenchmark: 'Update, overwrite, delete, merge, and abstention behavior after lifecycle operations',
+      guardBenchmark: 'Memory-before-action controller behavior: receipts, learned tool-failure cautions, and strict blocking reflexes',
       externalLeaderboard: 'Published LoCoMo scores from official papers and project blogs',
     },
     local: {
       overall: localOverall,
+      overall_scope: overallScope,
+      overall_suite_ids: overallSuiteIds,
       byFamily: localByFamily,
       suites: localSuites,
       cases: caseResults,

--- a/docs/PRODUCTION_BACKLOG.md
+++ b/docs/PRODUCTION_BACKLOG.md
@@ -135,11 +135,15 @@ Open questions before committing to the rename:
 Concrete v0.23 work the audit identified, scoped to fit one or two
 releases:
 
+0. Audrey Guard controller shipped in the v0.23 branch:
+   `beforeAction()` / `afterAction()` plus REST, MCP, and CLI surfaces.
+   The first slice uses `memory_events` metadata as receipts and avoids a
+   schema migration.
 1. `npx audrey guard --tool <Tool> "<command>"` CLI that returns
-   `allow` / `warn` / `block` with evidence and is the headline demo.
+   `go` / `caution` / `block` with evidence and is the headline demo.
 2. Memory Controller Layer (`src/controller.ts`) that owns
-   `beforeAction(action) → GuardResult` and
-   `afterAction(outcome) → void` over the existing primitives. This
+   `beforeAction(action) → GuardDecision` and
+   `afterAction(outcome) → GuardOutcome` over the existing primitives. This
    chassis also enables splitting `src/audrey.ts` (now ~1.2K lines) into
    focused services.
 3. Actually batch embeddings in `Audrey.encodeBatch()` with

--- a/docs/PRODUCTION_BACKLOG.md
+++ b/docs/PRODUCTION_BACKLOG.md
@@ -137,8 +137,9 @@ releases:
 
 0. Audrey Guard controller shipped in the v0.23 branch:
    `beforeAction()` / `afterAction()` plus REST, MCP, and CLI surfaces.
-   The first slice uses `memory_events` metadata as receipts and avoids a
-   schema migration.
+   The first slice uses `memory_events` metadata as receipts, avoids a
+   schema migration, and has a local guard-loop benchmark for prior
+   tool-failure cautions and strict must-follow blocking.
 1. `npx audrey guard --tool <Tool> "<command>"` CLI that returns
    `go` / `caution` / `block` with evidence and is the headline demo.
 2. Memory Controller Layer (`src/controller.ts`) that owns

--- a/docs/superpowers/plans/2026-05-05-audrey-guard-controller-implementation.md
+++ b/docs/superpowers/plans/2026-05-05-audrey-guard-controller-implementation.md
@@ -1,0 +1,1560 @@
+# Audrey Guard Controller Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Audrey Guard as the v0.23 controller loop that checks memory before action, returns evidence-backed go/caution/block decisions, records an auditable receipt, and learns from post-action outcomes.
+
+**Architecture:** Add a focused `src/controller.ts` that composes existing `preflight`, reflex mapping, `observeTool`, `validate`, and `memory_events` metadata without a schema migration. Expose the controller through `Audrey.beforeAction()` / `Audrey.afterAction()`, REST routes, MCP tools, CLI subcommands, and docs. Keep `memory_preflight` and `memory_reflexes` intact.
+
+**Tech Stack:** TypeScript, Node.js 20+, SQLite via `better-sqlite3`, Vitest, Hono REST routes, MCP SDK, existing Audrey CLI in `mcp-server/index.ts`.
+
+---
+
+## Research Notes
+
+- Claude Code hooks are the key enforcement point: `PreToolUse` runs before a tool call and can allow, deny, ask, or defer; `PostToolUse` runs after tool completion and can provide feedback. Source: https://code.claude.com/docs/en/hooks
+- LangGraph's memory docs distinguish short-term and long-term memory and explicitly name semantic, episodic, and procedural memory. Audrey already has these memory types; Guard makes them operational before action. Source: https://docs.langchain.com/oss/python/concepts/memory
+- Mem0 positions itself as a production memory layer with MCP tools for add/search/update/delete/list events. Audrey's differentiator should not be "also an MCP memory server"; it should be the before/after action controller. Sources: https://docs.mem0.ai/platform/overview and https://docs.mem0.ai/platform/mem0-mcp
+- Letta memory blocks stay visible in context and can store tool guidelines, shared policies, and scratchpad state. Audrey Guard should produce compact machine/human guidance without forcing every memory to stay always visible. Source: https://docs.letta.com/guides/core-concepts/memory/memory-blocks
+- Zep emphasizes a dynamic knowledge graph and context block. Audrey's near-term wedge should remain local-first action receipts and feedback loops rather than competing head-on as a hosted graph store. Source: https://help.getzep.com/concepts
+
+## Agent Research Summary
+
+Two read-only explorer agents reviewed the repo.
+
+- Controller-core agent found the cleanest path is to run preflight once, then extract a pure helper from `src/reflexes.ts` so `beforeAction()` derives reflexes from that same preflight result.
+- Surface agent found the right insertion points: REST routes beside `/v1/preflight`, MCP schemas beside existing preflight/reflex schemas, CLI commands in the existing dispatcher, and docs in README sidecar tables.
+- Both agents flagged the same pitfall: `evidence_ids` can include synthetic recent-failure ids like `failure:npm test:<timestamp>`, so `afterAction()` must skip nonexistent memory ids when applying validation feedback.
+
+## File Structure
+
+- Modify `src/reflexes.ts`: export a pure `buildReflexReportFromPreflight(preflight, options)` helper so existing `buildReflexReport()` and new controller code share one reflex mapping.
+- Create `src/controller.ts`: define `GuardBeforeOptions`, `GuardDecision`, `GuardAfterInput`, `GuardOutcome`, `beforeAction()`, and `afterAction()`.
+- Modify `src/audrey.ts`: add `beforeAction()` and `afterAction()` methods that delegate to the controller and emit `guard-before` / `guard-after` events.
+- Modify `src/index.ts`: export controller functions and types.
+- Modify `src/routes.ts`: add sanitized `POST /v1/guard/before` and `POST /v1/guard/after`.
+- Modify `mcp-server/index.ts`: add guard schemas, MCP tools, CLI parser/formatters, help text, and dispatcher entries.
+- Modify `README.md`: add Guard routes, CLI examples, and a short "memory before action" receipt demo.
+- Modify `docs/PRODUCTION_BACKLOG.md`: mark the v0.23 controller chassis as implemented in the v0.23 product direction section.
+- Add `tests/controller.test.js`: core controller tests.
+- Modify `tests/http-api.test.js`: REST guard tests.
+- Modify `tests/mcp-server.test.js`: schema and CLI tests.
+
+## Design Decisions Locked For v0.23
+
+- No database schema migration. Use existing `memory_events.metadata` JSON as the receipt link.
+- `beforeAction()` always records one `PreToolUse` event. Guard is receipt-bearing by definition; callers that do not want receipts should keep using `preflight()`.
+- `afterAction()` records `PostToolUse` for `succeeded`, `skipped`, `blocked`, or `unknown`; records `PostToolUseFailure` for `failed`.
+- Feedback uses an explicit `evidence_feedback` object mapping memory ids to `used`, `helpful`, or `wrong`.
+- Synthetic evidence ids that do not exist in memory tables are returned as skipped validation entries, not errors.
+- The CLI `guard --json` exits `1` for `decision=block` and `0` for `go` or `caution`. Human output also clearly shows blocked decisions.
+
+---
+
+### Task 1: Extract Single-Pass Reflex Builder
+
+**Files:**
+- Modify: `src/reflexes.ts`
+- Test: `tests/reflexes.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `tests/reflexes.test.js`:
+
+```js
+  it('builds reflexes from an existing preflight without running preflight again', async () => {
+    await audrey.encode({
+      content: 'Never deploy Audrey without checking the package tarball first.',
+      source: 'direct-observation',
+      tags: ['must-follow', 'release'],
+    });
+
+    const preflight = await audrey.preflight('deploy Audrey release', {
+      strict: true,
+      includeCapsule: false,
+    });
+
+    const { buildReflexReportFromPreflight } = await import('../dist/src/reflexes.js');
+    const report = buildReflexReportFromPreflight(preflight, { includePreflight: true });
+
+    expect(report.decision).toBe('block');
+    expect(report.reflexes.some(r => r.response_type === 'block')).toBe(true);
+    expect(report.preflight).toBe(preflight);
+    expect(report.evidence_ids).toEqual(preflight.evidence_ids);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/reflexes.test.js
+```
+
+Expected: FAIL because `buildReflexReportFromPreflight` is not exported.
+
+- [ ] **Step 3: Implement the pure helper**
+
+In `src/reflexes.ts`, add this function above `buildReflexReport()` and update `buildReflexReport()` to use it:
+
+```ts
+export function buildReflexReportFromPreflight(
+  preflight: MemoryPreflight,
+  options: Pick<ReflexOptions, 'includePreflight'> = {},
+): MemoryReflexReport {
+  const reflexes = preflight.warnings.map((warning): MemoryReflex => ({
+    id: reflexId(warning, preflight.action, preflight.tool),
+    trigger: triggerFor(warning, preflight.action, preflight.tool),
+    response_type: responseType(warning, preflight.decision),
+    severity: warning.severity,
+    source: warning.type,
+    response: responseFor(warning),
+    reason: warning.reason,
+    ...(warning.evidence_id ? { evidence_id: warning.evidence_id } : {}),
+    action: preflight.action,
+    ...(preflight.tool ? { tool: preflight.tool } : {}),
+    ...(preflight.cwd ? { cwd: preflight.cwd } : {}),
+  }));
+
+  return {
+    action: preflight.action,
+    query: preflight.query,
+    ...(preflight.tool ? { tool: preflight.tool } : {}),
+    ...(preflight.cwd ? { cwd: preflight.cwd } : {}),
+    generated_at: new Date().toISOString(),
+    decision: preflight.decision,
+    risk_score: preflight.risk_score,
+    summary: summarizeReflexes(preflight.decision, reflexes),
+    reflexes,
+    evidence_ids: preflight.evidence_ids,
+    recommended_actions: preflight.recommended_actions,
+    ...(options.includePreflight ? { preflight } : {}),
+  };
+}
+```
+
+Then replace the existing reflex construction in `buildReflexReport()` with:
+
+```ts
+export async function buildReflexReport(
+  audrey: Audrey,
+  action: string,
+  options: ReflexOptions = {},
+): Promise<MemoryReflexReport> {
+  const preflight = await buildPreflight(audrey, action, {
+    ...options,
+    includeCapsule: options.includeCapsule ?? false,
+  });
+
+  return buildReflexReportFromPreflight(preflight, options);
+}
+```
+
+- [ ] **Step 4: Export the helper from the package**
+
+In `src/index.ts`, change:
+
+```ts
+export { buildReflexReport } from './reflexes.js';
+```
+
+to:
+
+```ts
+export { buildReflexReport, buildReflexReportFromPreflight } from './reflexes.js';
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/reflexes.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/reflexes.ts src/index.ts tests/reflexes.test.js
+git commit -m "feat: derive reflexes from existing preflight"
+```
+
+---
+
+### Task 2: Add Controller Core
+
+**Files:**
+- Create: `src/controller.ts`
+- Modify: `src/audrey.ts`
+- Modify: `src/index.ts`
+- Test: `tests/controller.test.js`
+
+- [ ] **Step 1: Write the failing controller tests**
+
+Create `tests/controller.test.js`:
+
+```js
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, rmSync, mkdirSync } from 'node:fs';
+import { Audrey } from '../dist/src/index.js';
+
+const TEST_DIR = './test-controller-data';
+
+function metadataOf(event) {
+  return event.metadata ? JSON.parse(event.metadata) : {};
+}
+
+describe('Audrey Guard controller', () => {
+  let audrey;
+
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    audrey = new Audrey({
+      dataDir: TEST_DIR,
+      agent: 'controller-test',
+      embedding: { provider: 'mock', dimensions: 8 },
+    });
+  });
+
+  afterEach(() => {
+    audrey.close();
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  });
+
+  it('beforeAction returns go and records one receipt when no warnings exist', async () => {
+    const result = await audrey.beforeAction('format docs', {
+      tool: 'Bash',
+      sessionId: 'S-1',
+      includeCapsule: false,
+    });
+
+    expect(result.decision).toBe('go');
+    expect(result.ok_to_proceed).toBe(true);
+    expect(result.receipt_id).toMatch(/^01/);
+    expect(result.preflight_event_id).toBe(result.receipt_id);
+    expect(result.reflexes).toEqual([]);
+
+    const events = audrey.listEvents({ eventType: 'PreToolUse', toolName: 'Bash' });
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe(result.receipt_id);
+    expect(metadataOf(events[0]).guard).toBe(true);
+  });
+
+  it('beforeAction blocks strict high-severity memory and returns blocking reflexes', async () => {
+    await audrey.encode({
+      content: 'Never publish Audrey without running npm pack --dry-run first.',
+      source: 'direct-observation',
+      tags: ['must-follow', 'release'],
+    });
+
+    const result = await audrey.beforeAction('publish Audrey release', {
+      tool: 'npm publish',
+      strict: true,
+      includeCapsule: false,
+    });
+
+    expect(result.decision).toBe('block');
+    expect(result.ok_to_proceed).toBe(false);
+    expect(result.reflexes.some(r => r.response_type === 'block')).toBe(true);
+    expect(result.evidence_ids.some(id => !id.startsWith('failure:'))).toBe(true);
+  });
+
+  it('afterAction links the post event to the beforeAction receipt metadata', async () => {
+    const before = await audrey.beforeAction('run unit tests', {
+      tool: 'npm test',
+      sessionId: 'S-2',
+      includeCapsule: false,
+    });
+
+    const after = audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'npm test',
+      sessionId: 'S-2',
+      outcome: 'succeeded',
+      output: 'all tests passed\nraw details',
+    });
+
+    expect(after.receipt_id).toBe(before.receipt_id);
+    expect(after.post_event_id).toMatch(/^01/);
+    expect(after.outcome).toBe('succeeded');
+
+    const events = audrey.listEvents({ eventType: 'PostToolUse', toolName: 'npm test' });
+    expect(events).toHaveLength(1);
+    expect(events[0].session_id).toBe('S-2');
+    expect(metadataOf(events[0]).preflight_event_id).toBe(before.receipt_id);
+    expect(metadataOf(events[0]).guard).toBe(true);
+    expect(metadataOf(events[0]).output_summary).toBe('all tests passed');
+    expect(metadataOf(events[0]).redacted_output).toBeUndefined();
+  });
+
+  it('afterAction failure becomes a recent-failure warning on the next guard check', async () => {
+    const before = await audrey.beforeAction('run npm test', {
+      tool: 'npm test',
+      includeCapsule: false,
+    });
+
+    audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'npm test',
+      outcome: 'failed',
+      errorSummary: 'Vitest failed with spawn EPERM',
+    });
+
+    const next = await audrey.beforeAction('run npm test before release', {
+      tool: 'npm test',
+      includeCapsule: false,
+    });
+
+    expect(next.decision).toBe('caution');
+    expect(next.warnings.some(w => w.type === 'recent_failure')).toBe(true);
+  });
+
+  it('afterAction validates real evidence ids and skips synthetic failure ids', async () => {
+    const memoryId = await audrey.encode({
+      content: 'Never deploy without package tarball inspection.',
+      source: 'direct-observation',
+      tags: ['must-follow', 'release'],
+      salience: 0.5,
+    });
+    audrey.observeTool({
+      event: 'PostToolUse',
+      tool: 'deploy',
+      outcome: 'failed',
+      errorSummary: 'deploy failed before',
+    });
+
+    const before = await audrey.beforeAction('deploy Audrey release', {
+      tool: 'deploy',
+      strict: true,
+      includeCapsule: false,
+    });
+
+    const after = audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'deploy',
+      outcome: 'blocked',
+      evidenceFeedback: Object.fromEntries(before.evidence_ids.map(id => [id, 'helpful'])),
+    });
+
+    expect(after.validated_evidence.some(v => v.id === memoryId && v.validated)).toBe(true);
+    expect(after.validated_evidence.some(v => v.id.startsWith('failure:') && !v.validated)).toBe(true);
+
+    const impact = audrey.impact();
+    expect(impact.validatedTotal).toBe(1);
+    expect(impact.outcomeBreakdownInWindow.helpful).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/controller.test.js
+```
+
+Expected: FAIL because `audrey.beforeAction` and `audrey.afterAction` do not exist.
+
+- [ ] **Step 3: Create controller types and beforeAction implementation**
+
+Create `src/controller.ts`:
+
+```ts
+import type { Audrey } from './audrey.js';
+import type { EventOutcome } from './events.js';
+import type { MemoryValidateOutcome, MemoryValidateResult } from './feedback.js';
+import type { MemoryPreflight, PreflightOptions } from './preflight.js';
+import { buildPreflight } from './preflight.js';
+import {
+  buildReflexReportFromPreflight,
+  type MemoryReflex,
+} from './reflexes.js';
+
+export interface GuardBeforeOptions extends PreflightOptions {
+  recordEvent?: boolean;
+}
+
+export interface GuardDecision {
+  receipt_id: string;
+  preflight_event_id: string;
+  action: string;
+  query: string;
+  tool?: string;
+  cwd?: string;
+  generated_at: string;
+  decision: MemoryPreflight['decision'];
+  verdict: MemoryPreflight['verdict'];
+  ok_to_proceed: boolean;
+  risk_score: number;
+  summary: string;
+  warnings: MemoryPreflight['warnings'];
+  reflexes: MemoryReflex[];
+  recommended_actions: string[];
+  evidence_ids: string[];
+  recent_failures: MemoryPreflight['recent_failures'];
+  status?: MemoryPreflight['status'];
+  capsule?: MemoryPreflight['capsule'];
+}
+
+export interface GuardAfterInput {
+  receiptId: string;
+  tool?: string;
+  sessionId?: string;
+  input?: unknown;
+  output?: unknown;
+  outcome?: EventOutcome;
+  errorSummary?: string;
+  cwd?: string;
+  files?: string[];
+  metadata?: Record<string, unknown>;
+  retainDetails?: boolean;
+  evidenceFeedback?: Record<string, MemoryValidateOutcome>;
+}
+
+export interface GuardValidatedEvidence {
+  id: string;
+  outcome: MemoryValidateOutcome;
+  validated: boolean;
+  result?: MemoryValidateResult;
+  reason?: string;
+}
+
+export interface GuardOutcome {
+  receipt_id: string;
+  post_event_id: string;
+  outcome: EventOutcome;
+  validated_evidence: GuardValidatedEvidence[];
+  learning_summary: string;
+}
+
+function postEventTypeFor(outcome: EventOutcome): 'PostToolUse' | 'PostToolUseFailure' {
+  return outcome === 'failed' ? 'PostToolUseFailure' : 'PostToolUse';
+}
+
+function summarizeLearning(validated: GuardValidatedEvidence[]): string {
+  const applied = validated.filter(v => v.validated).length;
+  const skipped = validated.length - applied;
+  if (validated.length === 0) return 'Recorded action outcome; no evidence feedback supplied.';
+  return `Recorded action outcome; validated ${applied} evidence item${applied === 1 ? '' : 's'}`
+    + (skipped > 0 ? ` and skipped ${skipped} non-memory evidence item${skipped === 1 ? '' : 's'}.` : '.');
+}
+
+export async function beforeAction(audrey: Audrey, action: string, options: GuardBeforeOptions = {}): Promise<GuardDecision> {
+  const preflight = await buildPreflight(audrey, action, {
+    ...options,
+    recordEvent: true,
+  });
+  const reflexReport = buildReflexReportFromPreflight(preflight);
+  const receiptId = preflight.preflight_event_id;
+  if (!receiptId) {
+    throw new Error('guard beforeAction could not record a receipt event');
+  }
+
+  const events = audrey.listEvents({ eventType: 'PreToolUse', limit: 20 });
+  const receipt = events.find(event => event.id === receiptId);
+  if (receipt) {
+    const metadata = receipt.metadata ? JSON.parse(receipt.metadata) as Record<string, unknown> : {};
+    audrey.db.prepare('UPDATE memory_events SET metadata = ? WHERE id = ?').run(JSON.stringify({
+      ...metadata,
+      guard: true,
+      guard_phase: 'before',
+      evidence_ids: preflight.evidence_ids,
+      reflex_ids: reflexReport.reflexes.map(r => r.id),
+    }), receiptId);
+  }
+
+  return {
+    receipt_id: receiptId,
+    preflight_event_id: receiptId,
+    action: preflight.action,
+    query: preflight.query,
+    ...(preflight.tool ? { tool: preflight.tool } : {}),
+    ...(preflight.cwd ? { cwd: preflight.cwd } : {}),
+    generated_at: preflight.generated_at,
+    decision: preflight.decision,
+    verdict: preflight.verdict,
+    ok_to_proceed: preflight.ok_to_proceed,
+    risk_score: preflight.risk_score,
+    summary: preflight.summary,
+    warnings: preflight.warnings,
+    reflexes: reflexReport.reflexes,
+    recommended_actions: preflight.recommended_actions,
+    evidence_ids: preflight.evidence_ids,
+    recent_failures: preflight.recent_failures,
+    ...(preflight.status ? { status: preflight.status } : {}),
+    ...(preflight.capsule ? { capsule: preflight.capsule } : {}),
+  };
+}
+```
+
+- [ ] **Step 4: Add afterAction implementation**
+
+Append to `src/controller.ts`:
+
+```ts
+export function afterAction(audrey: Audrey, input: GuardAfterInput): GuardOutcome {
+  if (!input.receiptId || input.receiptId.trim().length === 0) {
+    throw new Error('receiptId is required');
+  }
+
+  const receipt = audrey.listEvents({ eventType: 'PreToolUse', limit: 1000 })
+    .find(event => event.id === input.receiptId);
+  if (!receipt) {
+    throw new Error(`guard receipt not found: ${input.receiptId}`);
+  }
+
+  const outcome = input.outcome ?? 'unknown';
+  const receiptMetadata = receipt.metadata ? JSON.parse(receipt.metadata) as Record<string, unknown> : {};
+  const result = audrey.observeTool({
+    event: postEventTypeFor(outcome),
+    tool: input.tool ?? receipt.tool_name ?? 'unknown',
+    sessionId: input.sessionId ?? receipt.session_id ?? undefined,
+    input: input.input,
+    output: input.output,
+    outcome,
+    errorSummary: input.errorSummary,
+    cwd: input.cwd ?? receipt.cwd ?? undefined,
+    files: input.files,
+    metadata: {
+      ...(input.metadata ?? {}),
+      guard: true,
+      guard_phase: 'after',
+      receipt_id: input.receiptId,
+      preflight_event_id: input.receiptId,
+      preflight_decision: receiptMetadata.preflight_decision,
+      preflight_warning_count: receiptMetadata.preflight_warning_count,
+    },
+    retainDetails: input.retainDetails,
+  });
+
+  const validated: GuardValidatedEvidence[] = [];
+  for (const [id, feedbackOutcome] of Object.entries(input.evidenceFeedback ?? {})) {
+    const feedback = audrey.validate({ id, outcome: feedbackOutcome });
+    if (feedback) {
+      validated.push({ id, outcome: feedbackOutcome, validated: true, result: feedback });
+    } else {
+      validated.push({
+        id,
+        outcome: feedbackOutcome,
+        validated: false,
+        reason: 'No memory row matched this evidence id.',
+      });
+    }
+  }
+
+  return {
+    receipt_id: input.receiptId,
+    post_event_id: result.event.id,
+    outcome,
+    validated_evidence: validated,
+    learning_summary: summarizeLearning(validated),
+  };
+}
+```
+
+- [ ] **Step 5: Add Audrey class methods**
+
+In `src/audrey.ts`, add imports:
+
+```ts
+import {
+  beforeAction as guardBeforeAction,
+  afterAction as guardAfterAction,
+  type GuardBeforeOptions,
+  type GuardDecision,
+  type GuardAfterInput,
+  type GuardOutcome,
+} from './controller.js';
+```
+
+Add methods near `preflight()` and `reflexes()`:
+
+```ts
+  async beforeAction(action: string, options: GuardBeforeOptions = {}): Promise<GuardDecision> {
+    const decision = await guardBeforeAction(this, action, options);
+    this.emit('guard-before', decision);
+    return decision;
+  }
+
+  afterAction(input: GuardAfterInput): GuardOutcome {
+    const outcome = guardAfterAction(this, input);
+    this.emit('guard-after', outcome);
+    return outcome;
+  }
+```
+
+- [ ] **Step 6: Export controller types**
+
+In `src/index.ts`, add:
+
+```ts
+export { beforeAction, afterAction } from './controller.js';
+export type {
+  GuardBeforeOptions,
+  GuardDecision,
+  GuardAfterInput,
+  GuardOutcome,
+  GuardValidatedEvidence,
+} from './controller.js';
+```
+
+- [ ] **Step 7: Run controller tests**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/controller.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run preflight/reflex regression tests**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/preflight.test.js tests/reflexes.test.js tests/controller.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/controller.ts src/audrey.ts src/index.ts tests/controller.test.js
+git commit -m "feat: add Audrey Guard controller"
+```
+
+---
+
+### Task 3: Add REST Guard Routes
+
+**Files:**
+- Modify: `src/routes.ts`
+- Test: `tests/http-api.test.js`
+
+- [ ] **Step 1: Write failing REST tests**
+
+Add these tests after the existing `/v1/reflexes` test in `tests/http-api.test.js`:
+
+```js
+  it('POST /v1/guard/before returns a receipt-backed guard decision', async () => {
+    audrey.observeTool({
+      event: 'PostToolUse',
+      tool: 'npm test',
+      outcome: 'failed',
+      errorSummary: 'Vitest failed with spawn EPERM on this host',
+      cwd: process.cwd(),
+    });
+
+    const res = await app.request('/v1/guard/before', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action: 'run npm test before release',
+        tool: 'npm test',
+        include_capsule: false,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.receipt_id).toMatch(/^01/);
+    expect(body.decision).toBe('caution');
+    expect(body.reflexes.length).toBeGreaterThan(0);
+    expect(body.warnings.some(w => w.type === 'recent_failure')).toBe(true);
+  });
+
+  it('POST /v1/guard/before rejects blank action', async () => {
+    const res = await app.request('/v1/guard/before', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: '   ', tool: 'Bash' }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/action/i);
+  });
+
+  it('POST /v1/guard/after records redacted outcome linked to receipt', async () => {
+    const before = await audrey.beforeAction('call remote service', {
+      tool: 'curl',
+      includeCapsule: false,
+    });
+
+    const res = await app.request('/v1/guard/after', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        receipt_id: before.receipt_id,
+        tool: 'curl',
+        outcome: 'failed',
+        error_summary: 'request failed with token sk-test-secret',
+        output: 'token sk-test-secret appeared in stderr',
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.receipt_id).toBe(before.receipt_id);
+    expect(body.post_event_id).toMatch(/^01/);
+    expect(JSON.stringify(body)).not.toContain('sk-test-secret');
+
+    const events = audrey.listEvents({ eventType: 'PostToolUseFailure', toolName: 'curl' });
+    expect(events).toHaveLength(1);
+    expect(events[0].error_summary).not.toContain('sk-test-secret');
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/http-api.test.js
+```
+
+Expected: FAIL because `/v1/guard/before` and `/v1/guard/after` do not exist.
+
+- [ ] **Step 3: Add explicit route body types**
+
+In `src/routes.ts`, extend `RouteBody` with:
+
+```ts
+  receipt_id?: string;
+  receiptId?: string;
+  input?: unknown;
+  output?: unknown;
+  outcome?: 'succeeded' | 'failed' | 'blocked' | 'skipped' | 'unknown';
+  error_summary?: string;
+  errorSummary?: string;
+  metadata?: Record<string, unknown>;
+  retain_details?: boolean;
+  retainDetails?: boolean;
+  evidence_feedback?: Record<string, 'used' | 'helpful' | 'wrong'>;
+  evidenceFeedback?: Record<string, 'used' | 'helpful' | 'wrong'>;
+```
+
+- [ ] **Step 4: Add sanitized guard routes**
+
+In `src/routes.ts`, add these routes after `/v1/reflexes`:
+
+```ts
+  app.post('/v1/guard/before', async (c) => {
+    try {
+      const body = await c.req.json();
+      const action = actionFromBody(body);
+      if (typeof action !== 'string' || action.trim().length === 0) {
+        return c.json({ error: 'action must be a non-empty string' }, 400);
+      }
+
+      const result = await audrey.beforeAction(action, {
+        ...preflightOptionsFromBody(body),
+        recordEvent: true,
+      });
+      return c.json(result);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: message }, 400);
+    }
+  });
+
+  app.post('/v1/guard/after', async (c) => {
+    try {
+      const body = await c.req.json();
+      const receiptId = body.receipt_id ?? body.receiptId;
+      if (typeof receiptId !== 'string' || receiptId.trim().length === 0) {
+        return c.json({ error: 'receipt_id is required' }, 400);
+      }
+
+      const result = audrey.afterAction({
+        receiptId,
+        tool: body.tool,
+        sessionId: body.session_id ?? body.sessionId,
+        input: body.input,
+        output: body.output,
+        outcome: body.outcome,
+        errorSummary: body.error_summary ?? body.errorSummary,
+        cwd: body.cwd,
+        files: body.files,
+        metadata: body.metadata,
+        retainDetails: body.retain_details ?? body.retainDetails,
+        evidenceFeedback: body.evidence_feedback ?? body.evidenceFeedback,
+      });
+      return c.json(result);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      const status = /receipt not found/i.test(message) ? 404 : 400;
+      return c.json({ error: message }, status);
+    }
+  });
+```
+
+- [ ] **Step 5: Run REST tests**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/http-api.test.js tests/controller.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/routes.ts tests/http-api.test.js
+git commit -m "feat: expose guard controller over REST"
+```
+
+---
+
+### Task 4: Add MCP Guard Tools And Schemas
+
+**Files:**
+- Modify: `mcp-server/index.ts`
+- Test: `tests/mcp-server.test.js`
+
+- [ ] **Step 1: Write failing schema tests**
+
+Update the imports in `tests/mcp-server.test.js` to include:
+
+```js
+  memoryGuardBeforeToolSchema,
+  memoryGuardAfterToolSchema,
+```
+
+Add these tests near the existing `memory_preflight` and `memory_reflexes` schema tests:
+
+```js
+  it('memory_guard_before mirrors preflight inputs', () => {
+    const schema = z.object(memoryGuardBeforeToolSchema);
+    expect(schema.safeParse({ action: '', tool: 'Bash' }).success).toBe(false);
+    expect(schema.safeParse({
+      action: 'run npm test',
+      tool: 'npm test',
+      strict: true,
+      failure_window_hours: 24,
+      record_event: true,
+      include_capsule: false,
+      scope: 'agent',
+    }).success).toBe(true);
+  });
+
+  it('memory_guard_after accepts observe-tool outcome payloads', () => {
+    const schema = z.object(memoryGuardAfterToolSchema);
+    expect(schema.safeParse({
+      receipt_id: '01KTESTRECEIPT',
+      tool: 'npm test',
+      outcome: 'failed',
+      error_summary: 'test failed',
+      metadata: { source: 'unit-test' },
+      evidence_feedback: { '01KMEMORY': 'helpful' },
+    }).success).toBe(true);
+    expect(schema.safeParse({
+      receipt_id: '01KTESTRECEIPT',
+      tool: 'npm test',
+      outcome: 'exploded',
+    }).success).toBe(false);
+  });
+```
+
+- [ ] **Step 2: Run schema tests to verify they fail**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/mcp-server.test.js
+```
+
+Expected: FAIL because guard schemas are not exported.
+
+- [ ] **Step 3: Add MCP schemas**
+
+In `mcp-server/index.ts`, add after `memoryReflexesToolSchema`:
+
+```ts
+export const memoryGuardBeforeToolSchema = {
+  ...memoryPreflightToolSchema,
+};
+
+export const memoryGuardAfterToolSchema = {
+  receipt_id: z.string().refine(isNonEmptyText, 'Receipt id must not be empty').describe('Guard receipt id returned by memory_guard_before.'),
+  tool: z.string().optional().describe('Tool name observed after the guard decision.'),
+  session_id: z.string().optional().describe('Session identifier for grouping related events.'),
+  input: z.unknown().optional().describe('Tool input. Hashed and not stored raw unless retain_details is true.'),
+  output: z.unknown().optional().describe('Tool output. Summarized by default; redacted if retained.'),
+  outcome: z.enum(['succeeded', 'failed', 'blocked', 'skipped', 'unknown']).optional().describe('Post-action execution outcome.'),
+  error_summary: z.string().optional().describe('Short error description if the tool failed. Redacted and truncated.'),
+  cwd: z.string().optional().describe('Working directory at the time of the tool call.'),
+  files: z.array(z.string()).optional().describe('File paths to fingerprint.'),
+  metadata: z.record(z.string(), z.unknown()).optional().describe('Additional structured metadata, redacted before storage.'),
+  retain_details: z.boolean().optional().describe('If true, redacted input/output payloads are stored alongside hashes.'),
+  evidence_feedback: z.record(z.string(), z.enum(['used', 'helpful', 'wrong'])).optional().describe(
+    'Map evidence memory ids to feedback outcomes. Synthetic evidence ids are skipped.'
+  ),
+};
+```
+
+- [ ] **Step 4: Register MCP tools**
+
+In `mcp-server/index.ts`, add after `memory_reflexes`:
+
+```ts
+  server.tool('memory_guard_before', memoryGuardBeforeToolSchema, async ({
+    action,
+    tool,
+    session_id,
+    cwd,
+    files,
+    strict,
+    limit,
+    budget_chars,
+    mode,
+    failure_window_hours,
+    include_status,
+    record_event,
+    include_capsule,
+    scope,
+  }) => {
+    try {
+      const result = await audrey.beforeAction(action, {
+        tool,
+        sessionId: session_id,
+        cwd,
+        files,
+        strict,
+        limit,
+        budgetChars: budget_chars,
+        mode,
+        recentFailureWindowHours: failure_window_hours,
+        includeStatus: include_status,
+        recordEvent: true,
+        includeCapsule: include_capsule,
+        scope: scope ?? 'agent',
+      });
+      return toolResult(result);
+    } catch (err) {
+      return toolError(err);
+    }
+  });
+
+  server.tool('memory_guard_after', memoryGuardAfterToolSchema, async ({
+    receipt_id,
+    tool,
+    session_id,
+    input,
+    output,
+    outcome,
+    error_summary,
+    cwd,
+    files,
+    metadata,
+    retain_details,
+    evidence_feedback,
+  }) => {
+    try {
+      const result = audrey.afterAction({
+        receiptId: receipt_id,
+        tool,
+        sessionId: session_id,
+        input,
+        output,
+        outcome,
+        errorSummary: error_summary,
+        cwd,
+        files,
+        metadata,
+        retainDetails: retain_details,
+        evidenceFeedback: evidence_feedback,
+      });
+      return toolResult(result);
+    } catch (err) {
+      return toolError(err);
+    }
+  });
+```
+
+- [ ] **Step 5: Run MCP tests**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/mcp-server.test.js tests/controller.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp-server/index.ts tests/mcp-server.test.js
+git commit -m "feat: add guard MCP tools"
+```
+
+---
+
+### Task 5: Add Guard CLI Commands
+
+**Files:**
+- Modify: `mcp-server/index.ts`
+- Test: `tests/mcp-server.test.js`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Add these tests to the `describe('CLI surface')` block in `tests/mcp-server.test.js`:
+
+```js
+  it('--help lists guard commands', () => {
+    const r = spawnSync(process.execPath, [cli, '--help'], { encoding: 'utf8', timeout: 10000 });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('guard');
+    expect(r.stdout).toContain('guard-after');
+  });
+
+  it('guard --json emits a machine-readable decision', () => {
+    const r = spawnSync(process.execPath, [
+      cli,
+      'guard',
+      '--json',
+      '--tool',
+      'Bash',
+      'list files before editing',
+    ], {
+      encoding: 'utf8',
+      timeout: 10000,
+      env: {
+        ...process.env,
+        AUDREY_DATA_DIR: './test-cli-guard',
+        AUDREY_EMBEDDING_PROVIDER: 'mock',
+      },
+    });
+    expect(r.status).toBe(0);
+    const body = JSON.parse(r.stdout);
+    expect(body.receipt_id).toMatch(/^01/);
+    expect(body.decision).toBe('go');
+    expect(Array.isArray(body.evidence_ids)).toBe(true);
+  });
+
+  it('guard requires an action', () => {
+    const r = spawnSync(process.execPath, [cli, 'guard', '--tool', 'Bash'], { encoding: 'utf8', timeout: 10000 });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('guard: action is required');
+  });
+```
+
+Add this cleanup inside the `describe('CLI surface')` block in `tests/mcp-server.test.js`, directly after `const cli = resolve('dist/mcp-server/index.js');`:
+
+```js
+  afterEach(() => {
+    if (existsSync('./test-cli-guard')) rmSync('./test-cli-guard', { recursive: true });
+  });
+```
+
+- [ ] **Step 2: Run CLI tests to verify they fail**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/mcp-server.test.js
+```
+
+Expected: FAIL because `guard` is an unknown command.
+
+- [ ] **Step 3: Add CLI parsers and formatters**
+
+In `mcp-server/index.ts`, add near `parseObserveToolArgs()`:
+
+```ts
+function parseGuardArgs(argv: string[]): {
+  action?: string;
+  tool?: string;
+  sessionId?: string;
+  cwd?: string;
+  strict?: boolean;
+  includeCapsule?: boolean;
+  json?: boolean;
+} {
+  const out: Record<string, unknown> = { includeCapsule: false };
+  const positionals: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    const next = () => argv[++i];
+    if (token === '--tool') out.tool = next();
+    else if (token === '--session-id') out.sessionId = next();
+    else if (token === '--cwd') out.cwd = next();
+    else if (token === '--strict') out.strict = true;
+    else if (token === '--include-capsule') out.includeCapsule = true;
+    else if (token === '--json') out.json = true;
+    else if (token && !token.startsWith('-')) positionals.push(token);
+  }
+  out.action = positionals.join(' ').trim();
+  return out as ReturnType<typeof parseGuardArgs>;
+}
+
+function formatGuardDecision(result: Awaited<ReturnType<Audrey['beforeAction']>>): string {
+  const lines = [
+    `[audrey] guard ${result.decision.toUpperCase()} - ${result.summary}`,
+    `receipt: ${result.receipt_id}`,
+  ];
+  if (result.recommended_actions.length > 0) {
+    lines.push('recommended actions:');
+    for (const action of result.recommended_actions.slice(0, 5)) {
+      lines.push(`  - ${action}`);
+    }
+  }
+  if (result.reflexes.length > 0) {
+    lines.push('reflexes:');
+    for (const reflex of result.reflexes.slice(0, 5)) {
+      lines.push(`  - ${reflex.response_type}: ${reflex.response}`);
+    }
+  }
+  return lines.join('\n');
+}
+```
+
+- [ ] **Step 4: Add guard CLI command**
+
+Add:
+
+```ts
+async function guardCli(): Promise<void> {
+  const args = parseGuardArgs(process.argv.slice(3));
+  if (!args.action) {
+    console.error('[audrey] guard: action is required');
+    process.exit(2);
+  }
+
+  const dataDir = resolveDataDir(process.env);
+  const embedding = resolveEmbeddingProvider(process.env, process.env['AUDREY_EMBEDDING_PROVIDER']);
+  const audrey = new Audrey({
+    dataDir,
+    agent: process.env['AUDREY_AGENT'] ?? 'guard',
+    embedding,
+  });
+
+  try {
+    const result = await audrey.beforeAction(args.action, {
+      tool: args.tool,
+      sessionId: args.sessionId,
+      cwd: args.cwd,
+      strict: args.strict,
+      includeCapsule: args.includeCapsule,
+      recordEvent: true,
+    });
+    if (args.json) console.log(JSON.stringify(result, null, 2));
+    else console.log(formatGuardDecision(result));
+    if (result.decision === 'block') process.exitCode = 1;
+  } finally {
+    await audrey.closeAsync();
+  }
+}
+```
+
+- [ ] **Step 5: Wire dispatcher and help**
+
+Update `KNOWN_SUBCOMMANDS` to include `'guard'` and `'guard-after'`.
+
+In `printHelp()`, add:
+
+```text
+  guard                         Check memory before an action and return a receipt
+  guard-after                   Record post-action outcome for a guard receipt
+```
+
+In the direct-run dispatcher, add before `impact`:
+
+```ts
+  } else if (subcommand === 'guard') {
+    guardCli().catch(err => {
+      console.error('[audrey] guard failed:', err);
+      process.exit(1);
+    });
+```
+
+- [ ] **Step 6: Run CLI tests**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/mcp-server.test.js
+```
+
+Expected: PASS for the new `guard` tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp-server/index.ts tests/mcp-server.test.js
+git commit -m "feat: add guard CLI before-action command"
+```
+
+---
+
+### Task 6: Add Guard-After CLI
+
+**Files:**
+- Modify: `mcp-server/index.ts`
+- Test: `tests/mcp-server.test.js`
+
+- [ ] **Step 1: Write failing guard-after CLI test**
+
+Add this test to the `describe('CLI surface')` block:
+
+```js
+  it('guard-after records hook-shaped stdin payloads', () => {
+    const before = spawnSync(process.execPath, [
+      cli,
+      'guard',
+      '--json',
+      '--tool',
+      'Bash',
+      'run a safe command',
+    ], {
+      encoding: 'utf8',
+      timeout: 10000,
+      env: {
+        ...process.env,
+        AUDREY_DATA_DIR: './test-cli-guard-after',
+        AUDREY_EMBEDDING_PROVIDER: 'mock',
+      },
+    });
+    expect(before.status).toBe(0);
+    const receipt = JSON.parse(before.stdout).receipt_id;
+
+    const after = spawnSync(process.execPath, [
+      cli,
+      'guard-after',
+      '--receipt',
+      receipt,
+    ], {
+      input: JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        session_id: 'S-cli',
+        tool_response: { success: true, stdout: 'ok' },
+      }),
+      encoding: 'utf8',
+      timeout: 10000,
+      env: {
+        ...process.env,
+        AUDREY_DATA_DIR: './test-cli-guard-after',
+        AUDREY_EMBEDDING_PROVIDER: 'mock',
+      },
+    });
+    expect(after.status).toBe(0);
+    const body = JSON.parse(after.stdout);
+    expect(body.receipt_id).toBe(receipt);
+    expect(body.post_event_id).toMatch(/^01/);
+    expect(body.outcome).toBe('succeeded');
+  });
+```
+
+Extend the same CLI `afterEach()` cleanup so it removes both guard test stores:
+
+```js
+  afterEach(() => {
+    if (existsSync('./test-cli-guard')) rmSync('./test-cli-guard', { recursive: true });
+    if (existsSync('./test-cli-guard-after')) rmSync('./test-cli-guard-after', { recursive: true });
+  });
+```
+
+- [ ] **Step 2: Run CLI tests to verify failure**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/mcp-server.test.js
+```
+
+Expected: FAIL because `guard-after` is not implemented.
+
+- [ ] **Step 3: Add parser**
+
+In `mcp-server/index.ts`, add:
+
+```ts
+function parseGuardAfterArgs(argv: string[]): {
+  receiptId?: string;
+  tool?: string;
+  sessionId?: string;
+  outcome?: 'succeeded' | 'failed' | 'blocked' | 'skipped' | 'unknown';
+  errorSummary?: string;
+  cwd?: string;
+  json?: boolean;
+} {
+  const out: Record<string, unknown> = { json: true };
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    const next = () => argv[++i];
+    if (token === '--receipt' || token === '--receipt-id') out.receiptId = next();
+    else if (token === '--tool') out.tool = next();
+    else if (token === '--session-id') out.sessionId = next();
+    else if (token === '--outcome') out.outcome = next();
+    else if (token === '--error-summary') out.errorSummary = next();
+    else if (token === '--cwd') out.cwd = next();
+    else if (token === '--json') out.json = true;
+  }
+  return out as ReturnType<typeof parseGuardAfterArgs>;
+}
+```
+
+- [ ] **Step 4: Add guard-after CLI command**
+
+Add:
+
+```ts
+async function guardAfterCli(): Promise<void> {
+  const args = parseGuardAfterArgs(process.argv.slice(3));
+  if (!args.receiptId) {
+    console.error('[audrey] guard-after: --receipt is required');
+    process.exit(2);
+  }
+
+  let stdinPayload: Record<string, unknown> | null = null;
+  if (!process.stdin.isTTY) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+    const raw = Buffer.concat(chunks).toString('utf-8').trim();
+    if (raw) {
+      try { stdinPayload = JSON.parse(raw) as Record<string, unknown>; }
+      catch { console.error('[audrey] guard-after: stdin was not valid JSON, ignoring.'); }
+    }
+  }
+
+  const resp = (stdinPayload?.tool_response as Record<string, unknown> | undefined) ?? undefined;
+  const successField = resp?.['success'];
+  const errField = resp?.['error'] ?? resp?.['stderr'];
+  const inferredOutcome = typeof successField === 'boolean'
+    ? (successField ? 'succeeded' : 'failed')
+    : errField ? 'failed' : undefined;
+
+  const dataDir = resolveDataDir(process.env);
+  const embedding = resolveEmbeddingProvider(process.env, process.env['AUDREY_EMBEDDING_PROVIDER']);
+  const audrey = new Audrey({
+    dataDir,
+    agent: process.env['AUDREY_AGENT'] ?? 'guard-after',
+    embedding,
+  });
+
+  try {
+    const result = audrey.afterAction({
+      receiptId: args.receiptId,
+      tool: args.tool ?? (stdinPayload?.tool_name as string | undefined),
+      sessionId: args.sessionId ?? (stdinPayload?.session_id as string | undefined),
+      input: stdinPayload?.tool_input ?? stdinPayload?.input,
+      output: stdinPayload?.tool_response ?? stdinPayload?.tool_output ?? stdinPayload?.output,
+      outcome: args.outcome ?? inferredOutcome,
+      errorSummary: args.errorSummary ?? (typeof errField === 'string' ? errField : undefined),
+      cwd: args.cwd ?? (stdinPayload?.cwd as string | undefined),
+    });
+    console.log(JSON.stringify(result, null, 2));
+  } finally {
+    await audrey.closeAsync();
+  }
+}
+```
+
+- [ ] **Step 5: Wire dispatcher**
+
+Add dispatcher branch:
+
+```ts
+  } else if (subcommand === 'guard-after') {
+    guardAfterCli().catch(err => {
+      console.error('[audrey] guard-after failed:', err);
+      process.exit(1);
+    });
+```
+
+- [ ] **Step 6: Run CLI tests**
+
+Run:
+
+```bash
+npm run build && npx vitest run tests/mcp-server.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp-server/index.ts tests/mcp-server.test.js
+git commit -m "feat: add guard-after CLI outcome recording"
+```
+
+---
+
+### Task 7: Update Documentation And Product Story
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/PRODUCTION_BACKLOG.md`
+- Test: command-only docs verification
+
+- [ ] **Step 1: Update README command list**
+
+In `README.md`, change the CLI surface row to include `guard`:
+
+```md
+| CLI | `doctor`, `demo`, `guard`, `guard-after`, `install`, `mcp-config`, `status`, `dream`, `reembed`, `observe-tool`, `promote`, `impact` |
+```
+
+- [ ] **Step 2: Update REST sidecar table**
+
+In the REST table in `README.md`, add:
+
+```md
+| Guard an action before tool use | `POST /v1/guard/before` |
+| Record the outcome after tool use | `POST /v1/guard/after` |
+```
+
+- [ ] **Step 3: Add headline guard demo**
+
+Add a short section after "Core sidecar tools":
+
+````md
+## Audrey Guard
+
+Audrey Guard is the memory-before-action loop. It asks Audrey what matters before a tool runs, returns a receipt-backed `go`, `caution`, or `block` decision, and records the outcome afterward so memory quality improves over time.
+
+```bash
+npx audrey guard --tool "npm test" --strict "run npm test before release"
+npx audrey guard --json --tool "npm test" --strict "run npm test before release"
+```
+
+Agents and hooks should pair `guard` with `guard-after`:
+
+```bash
+npx audrey guard-after --receipt <receipt_id> --outcome failed --error-summary "Vitest failed with spawn EPERM"
+```
+````
+
+- [ ] **Step 4: Update production backlog**
+
+In `docs/PRODUCTION_BACKLOG.md`, add this bullet at the top of "v0.23 Product Direction":
+
+```md
+- Audrey Guard controller: `beforeAction()` / `afterAction()` plus REST, MCP, and CLI surfaces. The first v0.23 slice uses `memory_events` metadata as receipts and avoids a schema migration.
+```
+
+- [ ] **Step 5: Verify docs snippets reference real commands**
+
+Run:
+
+```bash
+rg -n "guard|guard-after|/v1/guard" README.md docs/PRODUCTION_BACKLOG.md
+node dist/mcp-server/index.js --help
+```
+
+Expected: README/backlog references are visible, and help includes `guard` and `guard-after`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md docs/PRODUCTION_BACKLOG.md
+git commit -m "docs: document Audrey Guard controller loop"
+```
+
+---
+
+### Task 8: Final Verification And Release Gate Slice
+
+**Files:**
+- No production file changes expected.
+
+- [ ] **Step 1: Run typecheck**
+
+Run:
+
+```bash
+npm run typecheck
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+npx vitest run tests/controller.test.js tests/preflight.test.js tests/reflexes.test.js tests/http-api.test.js tests/mcp-server.test.js
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 3: Run release-gate-compatible build checks**
+
+Run:
+
+```bash
+npm run build
+npm run bench:perf
+npm run bench:memory:check
+npm run pack:check
+```
+
+Expected: exit 0 for each command.
+
+- [ ] **Step 4: Run CLI smoke with an isolated mock store**
+
+Run:
+
+```bash
+rm -rf .audrey-guard-smoke
+AUDREY_DATA_DIR=.audrey-guard-smoke AUDREY_EMBEDDING_PROVIDER=mock node dist/mcp-server/index.js guard --json --tool "npm test" --strict "run npm test before release"
+```
+
+Expected: JSON with `receipt_id`, `decision`, `ok_to_proceed`, and `evidence_ids`.
+
+- [ ] **Step 5: Record post-action smoke**
+
+Use the `receipt_id` from Step 4:
+
+```bash
+AUDREY_DATA_DIR=.audrey-guard-smoke AUDREY_EMBEDDING_PROVIDER=mock node dist/mcp-server/index.js guard-after --receipt <receipt_id> --tool "npm test" --outcome failed --error-summary "smoke failure"
+```
+
+Expected: JSON with `post_event_id`, `receipt_id`, `outcome: "failed"`, and `learning_summary`.
+
+- [ ] **Step 6: Inspect git status**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: clean working tree and branch ahead by the new implementation commits.
+
+- [ ] **Step 7: Final commit if any verification docs changed**
+
+If verification reveals only transient smoke data, remove it:
+
+```bash
+rm -rf .audrey-guard-smoke
+git status --short
+```
+
+If no tracked files changed, do not create a commit.
+
+---
+
+## Self-Review
+
+Spec coverage:
+- Controller core: Tasks 1-2.
+- REST routes: Task 3.
+- MCP tools: Task 4.
+- CLI commands: Tasks 5-6.
+- Docs and product story: Task 7.
+- Verification: Task 8.
+
+No schema migration is planned. Existing routes/tools remain in place. Tests are written before production changes in every implementation task.
+
+## Execution Recommendation
+
+Use Subagent-Driven Development, but do not start implementation directly on `master`. Create a worktree or feature branch first, then assign one task at a time to a fresh worker with spec and quality review between tasks.

--- a/docs/superpowers/specs/2026-05-05-audrey-guard-controller-design.md
+++ b/docs/superpowers/specs/2026-05-05-audrey-guard-controller-design.md
@@ -1,0 +1,239 @@
+# Audrey Guard Controller Design
+
+Date: 2026-05-05
+Status: draft for user review
+Target release: v0.23
+
+## Purpose
+
+Audrey already has recall, capsules, preflight, reflexes, tool traces, validation, and impact reporting. The missing product shape is a single loop that an agent can call before and after actions.
+
+This design makes Audrey Guard the headline v0.23 feature:
+
+- Before action: classify the action, recall relevant memory, decide go, caution, or block, and return evidence-backed guidance.
+- After action: record what happened, link it back to the guard decision, and reinforce or challenge the memories that influenced the action.
+- Over time: produce auditable proof that Audrey prevented repeated mistakes, improved outcomes, and learned from wrong guidance.
+
+The commercial wedge is not "another local vector database." It is "memory before action for AI agents that need to stop repeating expensive mistakes."
+
+## Audrey Self-Use Evidence
+
+During analysis, Audrey was run against `.audrey-working-memory` with mock embeddings. It stored the user's commercial ambition as must-follow memory and blocked a loose "improve Audrey" action in strict preflight mode until the work was framed as an ambitious product loop. That behavior is exactly the product promise v0.23 should make usable by agent hosts.
+
+## Approaches Considered
+
+### Approach A: Guard CLI only
+
+Add `audrey guard --tool <Tool> "<action>"` as a thin wrapper around `preflight()` and `reflexes()`.
+
+Pros:
+- Fastest demo.
+- Low risk.
+- Minimal API churn.
+
+Cons:
+- Does not give SDK, REST, or MCP callers one durable abstraction.
+- Does not close the loop after the action.
+- Risks becoming another disconnected primitive.
+
+### Approach B: Memory Controller core plus guard surfaces
+
+Add `src/controller.ts` with `beforeAction()` and `afterAction()`. Then expose it through the JS SDK, REST, MCP, and CLI.
+
+Pros:
+- Creates one product loop over existing Audrey primitives.
+- Keeps the headline demo simple while giving serious integrators a stable API.
+- Lets future work add action classification, replay scheduling, policy, and team audit without rewriting host surfaces.
+
+Cons:
+- More design work than a CLI wrapper.
+- Requires careful compatibility with existing preflight and tool-trace behavior.
+
+### Approach C: Policy engine and enforcement runtime
+
+Build a richer rules engine with custom policies, hard blocks, signed receipts, and host adapters first.
+
+Pros:
+- Strong enterprise story.
+- Clear path to paid team controls.
+
+Cons:
+- Too large for the next release.
+- High chance of burying the simple memory-before-action demo under configuration.
+
+## Recommendation
+
+Use Approach B.
+
+The first release should add a small controller core and guard surfaces without a new policy language or schema migration. It should feel like Audrey gained a spine, not like it gained a new subsystem.
+
+## Product Promise
+
+Audrey Guard answers four questions before an agent acts:
+
+1. What does Audrey remember that matters here?
+2. Should the agent proceed, slow down, or stop?
+3. What exact evidence caused that decision?
+4. How will Audrey learn whether the decision helped?
+
+The output must be useful to both machines and humans. Machine callers need stable fields. Humans need a compact explanation and a receipt id they can audit later.
+
+## Architecture
+
+Add a new controller module:
+
+```ts
+// src/controller.ts
+beforeAction(action, options) -> GuardDecision
+afterAction(receiptOrInput, outcome) -> GuardOutcome
+```
+
+The controller composes existing primitives:
+
+- `preflight()` provides the evidence packet, warnings, risk score, and go/caution/block decision.
+- Reflex generation provides trigger-response guidance from the same preflight result.
+- `observeTool()` records pre-action and post-action events.
+- `validate()` reinforces or challenges evidence memories.
+- `impact()` later shows whether the loop is doing useful work.
+
+The controller should be imported by `src/audrey.ts`, not buried in the CLI. All external surfaces call the same implementation.
+
+Implementation should avoid two independent recall/preflight passes for one guard check. Either extract an internal `reflexesFromPreflight()` helper from `src/reflexes.ts`, or add an option that lets the controller pass an already-built preflight result into reflex generation.
+
+## Core Types
+
+`GuardDecision` should include:
+
+- `receipt_id`: the `memory_events` id for the recorded guard check.
+- `action`, `tool`, `cwd`, `generated_at`.
+- `decision`: `go`, `caution`, or `block`.
+- `ok_to_proceed`: false only for block.
+- `risk_score`.
+- `summary`.
+- `warnings`.
+- `reflexes`.
+- `recommended_actions`.
+- `evidence_ids`.
+- `capsule` when requested.
+- `status` when requested.
+
+`GuardOutcome` should include:
+
+- `receipt_id`.
+- `post_event_id`.
+- `outcome`: `succeeded`, `failed`, `blocked`, `skipped`, or `unknown`.
+- `validated_evidence`: ids that were marked `used`, `helpful`, or `wrong`.
+- `learning_summary`: a compact statement of what Audrey learned or why it abstained.
+
+## Data Flow
+
+### Before Action
+
+1. Caller sends action text plus optional tool, cwd, session id, files, strict mode, and capsule budget.
+2. Controller calls `preflight()` with `recordEvent: true`.
+3. Controller derives reflexes from that same preflight result, avoiding duplicate recall and duplicate event creation.
+4. Controller returns one `GuardDecision`.
+5. If `decision=block`, CLI exits non-zero and REST/MCP/SDK set `ok_to_proceed=false`.
+
+### After Action
+
+1. Caller sends the receipt id, outcome, optional error summary, output summary, and evidence feedback.
+2. Controller records a redacted post-action tool trace.
+3. If the action was blocked, it records `outcome=blocked` without pretending a tool ran.
+4. If evidence feedback is supplied, controller calls `validate()` for each memory id.
+5. Controller returns `GuardOutcome`.
+
+## External Surfaces
+
+### JavaScript SDK
+
+Add:
+
+```ts
+await audrey.beforeAction('run npm test before release', { tool: 'npm test', strict: true });
+await audrey.afterAction({ receiptId, outcome: 'failed', errorSummary });
+```
+
+### REST
+
+Add:
+
+- `POST /v1/guard/before`
+- `POST /v1/guard/after`
+
+Keep `/v1/preflight` and `/v1/reflexes` unchanged for compatibility.
+
+### MCP
+
+Add:
+
+- `memory_guard_before`
+- `memory_guard_after`
+
+The current `memory_preflight` and `memory_reflexes` remain available.
+
+### CLI
+
+Add:
+
+```bash
+npx audrey guard --tool "npm test" --strict "run npm test before release"
+npx audrey guard-after --receipt <id> --outcome failed --error-summary "..."
+```
+
+The first command is the headline demo. It should print a compact human report and support `--json`.
+
+## Error Handling
+
+- Empty action returns a validation error.
+- Unknown receipt id in `afterAction()` returns a controlled not-found error.
+- Memory health problems appear as high or medium warnings, consistent with `preflight()`.
+- If recall or FTS is degraded, the guard result must say so rather than imply full coverage.
+- Redaction remains centralized in `observeTool()`. Controller code must not store raw tool payloads directly.
+- Strict mode blocks only high-severity warnings, matching existing preflight semantics.
+
+## Compatibility
+
+This release should not remove or rename existing tools, routes, or SDK methods. It should only add a controller layer and guard surfaces.
+
+The controller should use existing `memory_events` rows as receipts so v0.23 can ship without a schema migration. A future paid/team version can add signed receipts and richer audit tables.
+
+## Testing
+
+Add focused tests before implementation:
+
+- Controller returns `go` when no warnings exist.
+- Controller returns `block` in strict mode for relevant must-follow memory.
+- Controller returns `caution` for a repeated failed tool action.
+- `beforeAction()` records exactly one guard/preflight event.
+- `afterAction()` records a post-action event linked to the receipt.
+- Evidence feedback calls validation and changes impact metrics.
+- REST guard routes sanitize options like current recall routes.
+- MCP schemas accept valid guard calls and reject malformed inputs.
+- CLI `guard --json` returns machine-readable `decision`, `receipt_id`, and `evidence_ids`.
+
+## Out Of Scope For v0.23
+
+- A full custom policy language.
+- Hosted sync.
+- Multi-tenant team authorization.
+- New database schema for signed receipts.
+- Automatic host hook installation.
+- Replacing existing preflight or reflex APIs.
+
+## Success Criteria
+
+The v0.23 demo should make this claim defensible:
+
+> Audrey remembered before acting, stopped or warned on known risks, recorded a receipt, and learned whether the guidance helped.
+
+Release gates:
+
+- `npm run typecheck`
+- Focused Vitest coverage for controller, REST, MCP schemas, and CLI parsing.
+- Existing preflight, reflexes, capsule, and http API tests still pass.
+- `npx audrey guard --json --tool "npm test" --strict "run npm test before release"` works against a mock-memory demo store.
+
+## Review Question
+
+If this spec is approved, the implementation plan should start with controller tests, then the core controller, then SDK, REST, MCP, CLI, docs, and final release-gate verification.

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -161,6 +161,31 @@ export const memoryPreflightToolSchema = {
   scope: z.enum(['agent', 'shared']).optional().describe('agent restricts memory recall to this server agent identity. shared searches the whole store. Defaults to agent.'),
 };
 
+export const memoryGuardBeforeToolSchema = memoryPreflightToolSchema;
+
+export const memoryGuardAfterToolSchema = {
+  receipt_id: z.string()
+    .refine(isNonEmptyText, 'Receipt id must not be empty')
+    .describe('Receipt id returned by memory_guard_before.'),
+  tool: z.string().optional().describe('Tool or command family that completed, e.g. Bash, npm test, Edit, deploy.'),
+  session_id: z.string().optional().describe('Session identifier for grouping related guard events.'),
+  input: z.unknown().optional().describe(
+    'Tool input. Hashed and never stored raw; redacted metadata is only stored when retain_details is true.'
+  ),
+  output: z.unknown().optional().describe('Tool output. Same redaction and storage policy as input.'),
+  outcome: z.enum(['succeeded', 'failed', 'blocked', 'skipped', 'unknown']).optional().describe('Outcome classification'),
+  error_summary: z.string().optional().describe('Short error description if the action failed. Redacted and truncated to 2 KB.'),
+  cwd: z.string().optional().describe('Working directory at the time of the action.'),
+  files: z.array(z.string()).optional().describe('File paths to fingerprint (size + mtime + content hash).'),
+  metadata: z.record(z.string(), z.unknown()).optional().describe('Arbitrary structured metadata (redacted before storage).'),
+  retain_details: z.boolean().optional().describe(
+    'If true, redacted input and output payloads are stored alongside hashes. Defaults to false.'
+  ),
+  evidence_feedback: z.record(z.string(), z.enum(['used', 'helpful', 'wrong'])).optional().describe(
+    'Map of evidence ids from the guard receipt to memory validation outcomes.'
+  ),
+};
+
 export const memoryReflexesToolSchema = {
   ...memoryPreflightToolSchema,
   include_preflight: z.boolean().optional().describe('If true, include the full underlying preflight report.'),
@@ -651,6 +676,8 @@ Audrey registered as "${SERVER_NAME}" with Claude Code.
   memory_recent_failures - Inspect recent failed tool events
   memory_capsule       - Return a ranked, evidence-backed memory packet
   memory_preflight     - Check memory before an agent acts
+  memory_guard_before  - Create a guard receipt before an agent acts
+  memory_guard_after   - Record the outcome for a guard receipt
   memory_reflexes      - Convert preflight evidence into trigger-response reflexes
   memory_promote       - Promote repeated lessons into project rules
 
@@ -1806,6 +1833,78 @@ async function main(): Promise<void> {
         scope: scope ?? 'agent',
       });
       return toolResult(preflight);
+    } catch (err) {
+      return toolError(err);
+    }
+  });
+
+  server.tool('memory_guard_before', memoryGuardBeforeToolSchema, async ({
+    action,
+    tool,
+    session_id,
+    cwd,
+    files,
+    strict,
+    limit,
+    budget_chars,
+    mode,
+    failure_window_hours,
+    include_status,
+    include_capsule,
+    scope,
+  }) => {
+    try {
+      const decision = await audrey.beforeAction(action, {
+        tool,
+        sessionId: session_id,
+        cwd,
+        files,
+        strict,
+        limit,
+        budgetChars: budget_chars,
+        mode,
+        recentFailureWindowHours: failure_window_hours,
+        includeStatus: include_status,
+        recordEvent: true,
+        includeCapsule: include_capsule,
+        scope: scope ?? 'agent',
+      });
+      return toolResult(decision);
+    } catch (err) {
+      return toolError(err);
+    }
+  });
+
+  server.tool('memory_guard_after', memoryGuardAfterToolSchema, async ({
+    receipt_id,
+    tool,
+    session_id,
+    input,
+    output,
+    outcome,
+    error_summary,
+    cwd,
+    files,
+    metadata,
+    retain_details,
+    evidence_feedback,
+  }) => {
+    try {
+      const result = audrey.afterAction({
+        receiptId: receipt_id,
+        tool,
+        sessionId: session_id,
+        input,
+        output,
+        outcome,
+        errorSummary: error_summary,
+        cwd,
+        files,
+        metadata,
+        retainDetails: retain_details,
+        evidenceFeedback: evidence_feedback,
+      });
+      return toolResult(result);
     } catch (err) {
       return toolError(err);
     }

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -2342,7 +2342,6 @@ Commands:
   reflect                       End-of-session memory capture from stdin transcript
   observe-tool                  Record a tool-trace event (--event, --tool, --outcome)
   guard                         Check memory before an action (--json, --tool, --strict)
-  guard-after                   Record a guarded action outcome (planned)
   impact                        Show closed-loop feedback metrics (--window N, --limit N, --json)
   promote                       Promote rules from observed traces (--dry-run to preview)
 

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -2223,6 +2223,103 @@ async function guardCli(): Promise<void> {
   }
 }
 
+function parseGuardAfterArgs(argv: string[]): {
+  receipt?: string;
+  tool?: string;
+  sessionId?: string;
+  outcome?: 'succeeded' | 'failed' | 'blocked' | 'skipped' | 'unknown';
+  errorSummary?: string;
+  cwd?: string;
+} {
+  const out: Record<string, unknown> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    const next = () => argv[++i];
+    if (token === '--receipt') out.receipt = next();
+    else if (token === '--tool') out.tool = next();
+    else if (token === '--session-id') out.sessionId = next();
+    else if (token === '--outcome') out.outcome = next();
+    else if (token === '--error-summary') out.errorSummary = next();
+    else if (token === '--cwd') out.cwd = next();
+  }
+  return out as ReturnType<typeof parseGuardAfterArgs>;
+}
+
+async function readOptionalJsonFromStdin(command: string): Promise<Record<string, unknown> | null> {
+  if (process.stdin.isTTY) return null;
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  const raw = Buffer.concat(chunks).toString('utf-8').trim();
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    console.error(`[audrey] ${command}: stdin was not valid JSON, ignoring.`);
+    return null;
+  }
+}
+
+function inferGuardAfterOutcome(
+  stdinPayload: Record<string, unknown> | null,
+): 'succeeded' | 'failed' | 'blocked' | 'skipped' | 'unknown' | undefined {
+  const response = (stdinPayload?.tool_response as Record<string, unknown> | undefined)
+    ?? (stdinPayload?.tool_output as Record<string, unknown> | undefined)
+    ?? (stdinPayload?.output as Record<string, unknown> | undefined);
+  const success = response?.success;
+  if (typeof success === 'boolean') return success ? 'succeeded' : 'failed';
+
+  const errField = response?.error ?? response?.stderr ?? stdinPayload?.error ?? stdinPayload?.stderr;
+  if (errField && (typeof errField !== 'string' || errField.length > 0)) return 'failed';
+  return undefined;
+}
+
+async function guardAfterCli(): Promise<void> {
+  const args = parseGuardAfterArgs(process.argv.slice(3));
+  if (!args.receipt) {
+    console.error('[audrey] guard-after: --receipt is required');
+    process.exit(2);
+  }
+
+  const stdinPayload = await readOptionalJsonFromStdin('guard-after');
+  const outputPayload = stdinPayload?.tool_response ?? stdinPayload?.tool_output ?? stdinPayload?.output;
+  const inputPayload = stdinPayload?.tool_input ?? stdinPayload?.input;
+  const outcome = args.outcome ?? inferGuardAfterOutcome(stdinPayload);
+
+  let errorSummary = args.errorSummary ?? (stdinPayload?.error_summary as string | undefined);
+  if (outcome === 'failed' && !errorSummary) {
+    const response = outputPayload && typeof outputPayload === 'object'
+      ? outputPayload as Record<string, unknown>
+      : undefined;
+    const errField = response?.error ?? response?.stderr ?? stdinPayload?.error ?? stdinPayload?.stderr;
+    if (typeof errField === 'string') errorSummary = errField;
+    else if (errField !== undefined) errorSummary = JSON.stringify(errField);
+  }
+
+  const dataDir = resolveDataDir(process.env);
+  const embedding = resolveEmbeddingProvider(process.env, process.env['AUDREY_EMBEDDING_PROVIDER']);
+  const audrey = new Audrey({
+    dataDir,
+    agent: process.env['AUDREY_AGENT'] ?? 'guard-after',
+    embedding,
+  });
+
+  try {
+    const result = audrey.afterAction({
+      receiptId: args.receipt,
+      tool: args.tool ?? (stdinPayload?.tool_name as string | undefined),
+      sessionId: args.sessionId ?? (stdinPayload?.session_id as string | undefined),
+      input: inputPayload,
+      output: outputPayload,
+      outcome,
+      errorSummary,
+      cwd: args.cwd ?? (stdinPayload?.cwd as string | undefined),
+    });
+    console.log(JSON.stringify(result));
+  } finally {
+    await audrey.closeAsync();
+  }
+}
+
 function parsePromoteArgs(argv: string[]): {
   target?: 'claude-rules' | 'agents-md' | 'playbook' | 'hook' | 'checklist';
   minConfidence?: number;
@@ -2320,7 +2417,7 @@ const isDirectRun = Boolean(process.argv[1])
 
 const KNOWN_SUBCOMMANDS = [
   'install', 'uninstall', 'mcp-config', 'demo', 'reembed', 'dream',
-  'greeting', 'reflect', 'serve', 'status', 'doctor', 'observe-tool', 'guard', 'promote', 'impact',
+  'greeting', 'reflect', 'serve', 'status', 'doctor', 'observe-tool', 'guard', 'guard-after', 'promote', 'impact',
 ] as const;
 
 function printHelp(): void {
@@ -2342,6 +2439,7 @@ Commands:
   reflect                       End-of-session memory capture from stdin transcript
   observe-tool                  Record a tool-trace event (--event, --tool, --outcome)
   guard                         Check memory before an action (--json, --tool, --strict)
+  guard-after                   Record a guarded action outcome (--receipt, --outcome)
   impact                        Show closed-loop feedback metrics (--window N, --limit N, --json)
   promote                       Promote rules from observed traces (--dry-run to preview)
 
@@ -2434,6 +2532,11 @@ if (isDirectRun) {
   } else if (subcommand === 'guard') {
     guardCli().catch(err => {
       console.error('[audrey] guard failed:', err);
+      process.exit(1);
+    });
+  } else if (subcommand === 'guard-after') {
+    guardAfterCli().catch(err => {
+      console.error('[audrey] guard-after failed:', err);
       process.exit(1);
     });
   } else if (subcommand === 'impact') {

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -2150,6 +2150,79 @@ async function observeToolCli(): Promise<void> {
   }
 }
 
+function parseGuardArgs(argv: string[]): {
+  json?: boolean;
+  tool?: string;
+  sessionId?: string;
+  cwd?: string;
+  strict?: boolean;
+  includeCapsule?: boolean;
+  action: string;
+} {
+  const action: string[] = [];
+  const out: Record<string, unknown> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i] ?? '';
+    const next = () => argv[++i];
+    if (token === '--json') out.json = true;
+    else if (token === '--tool') out.tool = next();
+    else if (token === '--session-id') out.sessionId = next();
+    else if (token === '--cwd') out.cwd = next();
+    else if (token === '--strict') out.strict = true;
+    else if (token === '--include-capsule') out.includeCapsule = true;
+    else action.push(token);
+  }
+  out.action = action.join(' ').trim();
+  return out as ReturnType<typeof parseGuardArgs>;
+}
+
+function formatGuardDecision(result: Awaited<ReturnType<Audrey['beforeAction']>>): string {
+  const lines = [
+    `[audrey] guard: decision=${result.decision} receipt=${result.receipt_id}`,
+    `summary: ${result.summary}`,
+  ];
+  if (result.warnings.length > 0) {
+    lines.push(`warnings: ${result.warnings.length}`);
+  }
+  return lines.join('\n');
+}
+
+async function guardCli(): Promise<void> {
+  const args = parseGuardArgs(process.argv.slice(3));
+  if (!args.action) {
+    console.error('[audrey] guard: action is required');
+    process.exit(2);
+  }
+
+  const dataDir = resolveDataDir(process.env);
+  const embedding = resolveEmbeddingProvider(process.env, process.env['AUDREY_EMBEDDING_PROVIDER']);
+  const audrey = new Audrey({
+    dataDir,
+    agent: process.env['AUDREY_AGENT'] ?? 'guard',
+    embedding,
+  });
+
+  try {
+    const result = await audrey.beforeAction(args.action, {
+      tool: args.tool,
+      sessionId: args.sessionId,
+      cwd: args.cwd,
+      strict: args.strict,
+      recordEvent: true,
+      includeCapsule: args.includeCapsule ?? false,
+    });
+
+    if (args.json) {
+      console.log(JSON.stringify(result));
+    } else {
+      console.log(formatGuardDecision(result));
+    }
+    process.exitCode = result.decision === 'block' ? 1 : 0;
+  } finally {
+    await audrey.closeAsync();
+  }
+}
+
 function parsePromoteArgs(argv: string[]): {
   target?: 'claude-rules' | 'agents-md' | 'playbook' | 'hook' | 'checklist';
   minConfidence?: number;
@@ -2247,7 +2320,7 @@ const isDirectRun = Boolean(process.argv[1])
 
 const KNOWN_SUBCOMMANDS = [
   'install', 'uninstall', 'mcp-config', 'demo', 'reembed', 'dream',
-  'greeting', 'reflect', 'serve', 'status', 'doctor', 'observe-tool', 'promote', 'impact',
+  'greeting', 'reflect', 'serve', 'status', 'doctor', 'observe-tool', 'guard', 'promote', 'impact',
 ] as const;
 
 function printHelp(): void {
@@ -2268,6 +2341,8 @@ Commands:
   greeting                      Emit session-start briefing (used by host hooks)
   reflect                       End-of-session memory capture from stdin transcript
   observe-tool                  Record a tool-trace event (--event, --tool, --outcome)
+  guard                         Check memory before an action (--json, --tool, --strict)
+  guard-after                   Record a guarded action outcome (planned)
   impact                        Show closed-loop feedback metrics (--window N, --limit N, --json)
   promote                       Promote rules from observed traces (--dry-run to preview)
 
@@ -2355,6 +2430,11 @@ if (isDirectRun) {
   } else if (subcommand === 'observe-tool') {
     observeToolCli().catch(err => {
       console.error('[audrey] observe-tool failed:', err);
+      process.exit(1);
+    });
+  } else if (subcommand === 'guard') {
+    guardCli().catch(err => {
+      console.error('[audrey] guard failed:', err);
       process.exit(1);
     });
   } else if (subcommand === 'impact') {

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -161,7 +161,12 @@ export const memoryPreflightToolSchema = {
   scope: z.enum(['agent', 'shared']).optional().describe('agent restricts memory recall to this server agent identity. shared searches the whole store. Defaults to agent.'),
 };
 
-export const memoryGuardBeforeToolSchema = memoryPreflightToolSchema;
+const { record_event: _preflightRecordEvent, ...memoryGuardBeforeFields } = memoryPreflightToolSchema;
+export const memoryGuardBeforeToolSchema = {
+  ...memoryGuardBeforeFields,
+  session_id: z.string().optional().describe('Session identifier for grouping the required guard receipt event.'),
+  files: z.array(z.string()).optional().describe('File paths to fingerprint in the required guard receipt.'),
+};
 
 export const memoryGuardAfterToolSchema = {
   receipt_id: z.string()

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "bench:perf-snapshot": "node benchmarks/perf-snapshot.js",
     "bench:memory:retrieval": "node benchmarks/run.js --suite retrieval",
     "bench:memory:operations": "node benchmarks/run.js --suite operations",
+    "bench:memory:guard": "node benchmarks/run.js --suite guard",
     "bench:memory:json": "node benchmarks/run.js --json",
     "bench:memory:check": "node benchmarks/run.js --check",
     "typecheck": "tsc --noEmit",

--- a/src/audrey.ts
+++ b/src/audrey.ts
@@ -60,6 +60,14 @@ import { buildCapsule, type CapsuleOptions, type MemoryCapsule } from './capsule
 import { buildPreflight, type MemoryPreflight, type PreflightOptions } from './preflight.js';
 import { buildReflexReport, type MemoryReflexReport, type ReflexOptions } from './reflexes.js';
 import {
+  beforeAction as guardBeforeAction,
+  afterAction as guardAfterAction,
+  type GuardBeforeOptions,
+  type GuardDecision,
+  type GuardAfterInput,
+  type GuardOutcome,
+} from './controller.js';
+import {
   findPromotionCandidates,
   type FindCandidatesOptions,
   type PromotionCandidate,
@@ -1033,6 +1041,18 @@ export class Audrey extends EventEmitter {
     const preflight = await buildPreflight(this, action, options);
     this.emit('preflight', preflight);
     return preflight;
+  }
+
+  async beforeAction(action: string, options: GuardBeforeOptions = {}): Promise<GuardDecision> {
+    const decision = await guardBeforeAction(this, action, options);
+    this.emit('guard-before', decision);
+    return decision;
+  }
+
+  afterAction(input: GuardAfterInput): GuardOutcome {
+    const outcome = guardAfterAction(this, input);
+    this.emit('guard-after', outcome);
+    return outcome;
   }
 
   async reflexes(action: string, options: ReflexOptions = {}): Promise<MemoryReflexReport> {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,5 +1,5 @@
 import type { Audrey } from './audrey.js';
-import type { EventOutcome } from './events.js';
+import type { EventOutcome, MemoryEvent } from './events.js';
 import type { MemoryValidateOutcome, MemoryValidateResult } from './feedback.js';
 import { buildPreflight, type MemoryPreflight, type PreflightOptions } from './preflight.js';
 import { buildReflexReportFromPreflight, type MemoryReflex } from './reflexes.js';
@@ -63,10 +63,28 @@ export interface GuardOutcome {
 
 function parseMetadata(value: string | null): Record<string, unknown> {
   if (!value) return {};
-  const parsed = JSON.parse(value) as unknown;
-  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-    ? parsed as Record<string, unknown>
-    : {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function getPreToolUseReceipt(audrey: Audrey, receiptId: string): MemoryEvent | null {
+  const receipt = audrey.db.prepare(`
+    SELECT * FROM memory_events
+    WHERE id = ? AND event_type = 'PreToolUse'
+  `).get(receiptId) as MemoryEvent | undefined;
+  return receipt ?? null;
+}
+
+function evidenceIdsFromMetadata(metadata: Record<string, unknown>): Set<string> {
+  const raw = metadata.evidence_ids;
+  if (!Array.isArray(raw)) return new Set();
+  return new Set(raw.filter((id): id is string => typeof id === 'string'));
 }
 
 function postEventTypeFor(outcome: EventOutcome): 'PostToolUse' | 'PostToolUseFailure' {
@@ -86,8 +104,10 @@ export async function beforeAction(
   action: string,
   options: GuardBeforeOptions = {},
 ): Promise<GuardDecision> {
+  const tool = options.tool ?? 'guard';
   const preflight = await buildPreflight(audrey, action, {
     ...options,
+    tool,
     recordEvent: true,
   });
   const reflexReport = buildReflexReportFromPreflight(preflight);
@@ -96,18 +116,18 @@ export async function beforeAction(
     throw new Error('guard beforeAction could not record a receipt event');
   }
 
-  const receipt = audrey.listEvents({ eventType: 'PreToolUse', limit: 1000 })
-    .find(event => event.id === receiptId);
-  if (receipt) {
-    const metadata = parseMetadata(receipt.metadata);
-    audrey.db.prepare('UPDATE memory_events SET metadata = ? WHERE id = ?').run(JSON.stringify({
-      ...metadata,
-      guard: true,
-      guard_phase: 'before',
-      evidence_ids: preflight.evidence_ids,
-      reflex_ids: reflexReport.reflexes.map(reflex => reflex.id),
-    }), receiptId);
+  const receipt = getPreToolUseReceipt(audrey, receiptId);
+  if (!receipt) {
+    throw new Error(`guard receipt not found: ${receiptId}`);
   }
+  const metadata = parseMetadata(receipt.metadata);
+  audrey.db.prepare('UPDATE memory_events SET metadata = ? WHERE id = ?').run(JSON.stringify({
+    ...metadata,
+    guard: true,
+    guard_phase: 'before',
+    evidence_ids: preflight.evidence_ids,
+    reflex_ids: reflexReport.reflexes.map(reflex => reflex.id),
+  }), receiptId);
 
   return {
     receipt_id: receiptId,
@@ -137,14 +157,14 @@ export function afterAction(audrey: Audrey, input: GuardAfterInput): GuardOutcom
     throw new Error('receiptId is required');
   }
 
-  const receipt = audrey.listEvents({ eventType: 'PreToolUse', limit: 1000 })
-    .find(event => event.id === input.receiptId);
+  const receipt = getPreToolUseReceipt(audrey, input.receiptId);
   if (!receipt) {
     throw new Error(`guard receipt not found: ${input.receiptId}`);
   }
 
   const outcome = input.outcome ?? 'unknown';
   const receiptMetadata = parseMetadata(receipt.metadata);
+  const receiptEvidenceIds = evidenceIdsFromMetadata(receiptMetadata);
   const result = audrey.observeTool({
     event: postEventTypeFor(outcome),
     tool: input.tool ?? receipt.tool_name ?? 'unknown',
@@ -169,6 +189,16 @@ export function afterAction(audrey: Audrey, input: GuardAfterInput): GuardOutcom
 
   const validated: GuardValidatedEvidence[] = [];
   for (const [id, feedbackOutcome] of Object.entries(input.evidenceFeedback ?? {})) {
+    if (!receiptEvidenceIds.has(id)) {
+      validated.push({
+        id,
+        outcome: feedbackOutcome,
+        validated: false,
+        reason: 'Evidence id was not part of the guard receipt evidence.',
+      });
+      continue;
+    }
+
     const feedback = audrey.validate({ id, outcome: feedbackOutcome });
     if (feedback) {
       validated.push({ id, outcome: feedbackOutcome, validated: true, result: feedback });

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,0 +1,192 @@
+import type { Audrey } from './audrey.js';
+import type { EventOutcome } from './events.js';
+import type { MemoryValidateOutcome, MemoryValidateResult } from './feedback.js';
+import { buildPreflight, type MemoryPreflight, type PreflightOptions } from './preflight.js';
+import { buildReflexReportFromPreflight, type MemoryReflex } from './reflexes.js';
+
+export interface GuardBeforeOptions extends PreflightOptions {
+  recordEvent?: boolean;
+}
+
+export interface GuardDecision {
+  receipt_id: string;
+  preflight_event_id: string;
+  action: string;
+  query: string;
+  tool?: string;
+  cwd?: string;
+  generated_at: string;
+  decision: MemoryPreflight['decision'];
+  verdict: MemoryPreflight['verdict'];
+  ok_to_proceed: boolean;
+  risk_score: number;
+  summary: string;
+  warnings: MemoryPreflight['warnings'];
+  reflexes: MemoryReflex[];
+  recommended_actions: string[];
+  evidence_ids: string[];
+  recent_failures: MemoryPreflight['recent_failures'];
+  status?: MemoryPreflight['status'];
+  capsule?: MemoryPreflight['capsule'];
+}
+
+export interface GuardAfterInput {
+  receiptId: string;
+  tool?: string;
+  sessionId?: string;
+  input?: unknown;
+  output?: unknown;
+  outcome?: EventOutcome;
+  errorSummary?: string;
+  cwd?: string;
+  files?: string[];
+  metadata?: Record<string, unknown>;
+  retainDetails?: boolean;
+  evidenceFeedback?: Record<string, MemoryValidateOutcome>;
+}
+
+export interface GuardValidatedEvidence {
+  id: string;
+  outcome: MemoryValidateOutcome;
+  validated: boolean;
+  result?: MemoryValidateResult;
+  reason?: string;
+}
+
+export interface GuardOutcome {
+  receipt_id: string;
+  post_event_id: string;
+  outcome: EventOutcome;
+  validated_evidence: GuardValidatedEvidence[];
+  learning_summary: string;
+}
+
+function parseMetadata(value: string | null): Record<string, unknown> {
+  if (!value) return {};
+  const parsed = JSON.parse(value) as unknown;
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {};
+}
+
+function postEventTypeFor(outcome: EventOutcome): 'PostToolUse' | 'PostToolUseFailure' {
+  return outcome === 'failed' ? 'PostToolUseFailure' : 'PostToolUse';
+}
+
+function summarizeLearning(validated: GuardValidatedEvidence[]): string {
+  const applied = validated.filter(v => v.validated).length;
+  const skipped = validated.length - applied;
+  if (validated.length === 0) return 'Recorded action outcome; no evidence feedback supplied.';
+  return `Recorded action outcome; validated ${applied} evidence item${applied === 1 ? '' : 's'}`
+    + (skipped > 0 ? ` and skipped ${skipped} non-memory evidence item${skipped === 1 ? '' : 's'}.` : '.');
+}
+
+export async function beforeAction(
+  audrey: Audrey,
+  action: string,
+  options: GuardBeforeOptions = {},
+): Promise<GuardDecision> {
+  const preflight = await buildPreflight(audrey, action, {
+    ...options,
+    recordEvent: true,
+  });
+  const reflexReport = buildReflexReportFromPreflight(preflight);
+  const receiptId = preflight.preflight_event_id;
+  if (!receiptId) {
+    throw new Error('guard beforeAction could not record a receipt event');
+  }
+
+  const receipt = audrey.listEvents({ eventType: 'PreToolUse', limit: 1000 })
+    .find(event => event.id === receiptId);
+  if (receipt) {
+    const metadata = parseMetadata(receipt.metadata);
+    audrey.db.prepare('UPDATE memory_events SET metadata = ? WHERE id = ?').run(JSON.stringify({
+      ...metadata,
+      guard: true,
+      guard_phase: 'before',
+      evidence_ids: preflight.evidence_ids,
+      reflex_ids: reflexReport.reflexes.map(reflex => reflex.id),
+    }), receiptId);
+  }
+
+  return {
+    receipt_id: receiptId,
+    preflight_event_id: receiptId,
+    action: preflight.action,
+    query: preflight.query,
+    ...(preflight.tool ? { tool: preflight.tool } : {}),
+    ...(preflight.cwd ? { cwd: preflight.cwd } : {}),
+    generated_at: preflight.generated_at,
+    decision: preflight.decision,
+    verdict: preflight.verdict,
+    ok_to_proceed: preflight.ok_to_proceed,
+    risk_score: preflight.risk_score,
+    summary: preflight.summary,
+    warnings: preflight.warnings,
+    reflexes: reflexReport.reflexes,
+    recommended_actions: preflight.recommended_actions,
+    evidence_ids: preflight.evidence_ids,
+    recent_failures: preflight.recent_failures,
+    ...(preflight.status ? { status: preflight.status } : {}),
+    ...(preflight.capsule ? { capsule: preflight.capsule } : {}),
+  };
+}
+
+export function afterAction(audrey: Audrey, input: GuardAfterInput): GuardOutcome {
+  if (!input.receiptId || input.receiptId.trim().length === 0) {
+    throw new Error('receiptId is required');
+  }
+
+  const receipt = audrey.listEvents({ eventType: 'PreToolUse', limit: 1000 })
+    .find(event => event.id === input.receiptId);
+  if (!receipt) {
+    throw new Error(`guard receipt not found: ${input.receiptId}`);
+  }
+
+  const outcome = input.outcome ?? 'unknown';
+  const receiptMetadata = parseMetadata(receipt.metadata);
+  const result = audrey.observeTool({
+    event: postEventTypeFor(outcome),
+    tool: input.tool ?? receipt.tool_name ?? 'unknown',
+    sessionId: input.sessionId ?? receipt.session_id ?? undefined,
+    input: input.input,
+    output: input.output,
+    outcome,
+    errorSummary: input.errorSummary,
+    cwd: input.cwd ?? receipt.cwd ?? undefined,
+    files: input.files,
+    metadata: {
+      ...(input.metadata ?? {}),
+      guard: true,
+      guard_phase: 'after',
+      receipt_id: input.receiptId,
+      preflight_event_id: input.receiptId,
+      preflight_decision: receiptMetadata.preflight_decision,
+      preflight_warning_count: receiptMetadata.preflight_warning_count,
+    },
+    retainDetails: input.retainDetails,
+  });
+
+  const validated: GuardValidatedEvidence[] = [];
+  for (const [id, feedbackOutcome] of Object.entries(input.evidenceFeedback ?? {})) {
+    const feedback = audrey.validate({ id, outcome: feedbackOutcome });
+    if (feedback) {
+      validated.push({ id, outcome: feedbackOutcome, validated: true, result: feedback });
+    } else {
+      validated.push({
+        id,
+        outcome: feedbackOutcome,
+        validated: false,
+        reason: 'No memory row matched this evidence id.',
+      });
+    }
+  }
+
+  return {
+    receipt_id: input.receiptId,
+    post_event_id: result.event.id,
+    outcome,
+    validated_evidence: validated,
+    learning_summary: summarizeLearning(validated),
+  };
+}

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -87,6 +87,39 @@ function evidenceIdsFromMetadata(metadata: Record<string, unknown>): Set<string>
   return new Set(raw.filter((id): id is string => typeof id === 'string'));
 }
 
+function isGuardBeforeReceipt(metadata: Record<string, unknown>): boolean {
+  return metadata.guard === true && metadata.guard_phase === 'before';
+}
+
+function isMemoryValidateOutcome(value: unknown): value is MemoryValidateOutcome {
+  return value === 'used' || value === 'helpful' || value === 'wrong';
+}
+
+function evidenceFeedbackEntries(
+  feedback: GuardAfterInput['evidenceFeedback'],
+): Array<[string, MemoryValidateOutcome]> {
+  const entries = Object.entries((feedback ?? {}) as Record<string, unknown>);
+  for (const [id, outcome] of entries) {
+    if (!isMemoryValidateOutcome(outcome)) {
+      throw new Error(`invalid evidence feedback outcome for ${id}: expected used, helpful, or wrong`);
+    }
+  }
+  return entries as Array<[string, MemoryValidateOutcome]>;
+}
+
+function getGuardOutcomeEvent(audrey: Audrey, receiptId: string): MemoryEvent | null {
+  const event = audrey.db.prepare(`
+    SELECT * FROM memory_events
+    WHERE event_type IN ('PostToolUse', 'PostToolUseFailure')
+      AND metadata IS NOT NULL
+      AND json_valid(metadata)
+      AND json_extract(metadata, '$.receipt_id') = ?
+    ORDER BY created_at DESC
+    LIMIT 1
+  `).get(receiptId) as MemoryEvent | undefined;
+  return event ?? null;
+}
+
 function postEventTypeFor(outcome: EventOutcome): 'PostToolUse' | 'PostToolUseFailure' {
   return outcome === 'failed' ? 'PostToolUseFailure' : 'PostToolUse';
 }
@@ -164,6 +197,13 @@ export function afterAction(audrey: Audrey, input: GuardAfterInput): GuardOutcom
 
   const outcome = input.outcome ?? 'unknown';
   const receiptMetadata = parseMetadata(receipt.metadata);
+  if (!isGuardBeforeReceipt(receiptMetadata)) {
+    throw new Error(`not a guard receipt: ${input.receiptId}`);
+  }
+  if (getGuardOutcomeEvent(audrey, input.receiptId)) {
+    throw new Error(`guard receipt already has an outcome: ${input.receiptId}`);
+  }
+  const feedbackEntries = evidenceFeedbackEntries(input.evidenceFeedback);
   const receiptEvidenceIds = evidenceIdsFromMetadata(receiptMetadata);
   const result = audrey.observeTool({
     event: postEventTypeFor(outcome),
@@ -188,7 +228,7 @@ export function afterAction(audrey: Audrey, input: GuardAfterInput): GuardOutcom
   });
 
   const validated: GuardValidatedEvidence[] = [];
-  for (const [id, feedbackOutcome] of Object.entries(input.evidenceFeedback ?? {})) {
+  for (const [id, feedbackOutcome] of feedbackEntries) {
     if (!receiptEvidenceIds.has(id)) {
       validated.push({
         id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export type {
   PreflightWarning,
   PreflightWarningType,
 } from './preflight.js';
-export { buildReflexReport } from './reflexes.js';
+export { buildReflexReport, buildReflexReportFromPreflight } from './reflexes.js';
 export type {
   MemoryReflex,
   MemoryReflexReport,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,14 @@ export type {
   ReflexOptions,
   ReflexResponseType,
 } from './reflexes.js';
+export { beforeAction, afterAction } from './controller.js';
+export type {
+  GuardBeforeOptions,
+  GuardDecision,
+  GuardAfterInput,
+  GuardOutcome,
+  GuardValidatedEvidence,
+} from './controller.js';
 
 export type {
   Affect,

--- a/src/reflexes.ts
+++ b/src/reflexes.ts
@@ -107,6 +107,13 @@ export async function buildReflexReport(
     includeCapsule: options.includeCapsule ?? false,
   });
 
+  return buildReflexReportFromPreflight(preflight, options);
+}
+
+export function buildReflexReportFromPreflight(
+  preflight: MemoryPreflight,
+  options: Pick<ReflexOptions, 'includePreflight'> = {},
+): MemoryReflexReport {
   const reflexes = preflight.warnings.map((warning): MemoryReflex => ({
     id: reflexId(warning, preflight.action, preflight.tool),
     trigger: triggerFor(warning, preflight.action, preflight.tool),

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { timingSafeEqual } from 'node:crypto';
 import type { Audrey } from './audrey.js';
+import type { EventOutcome } from './events.js';
 import type { PreflightOptions } from './preflight.js';
 import type { RecallOptions, MemoryType, PublicRetrievalMode } from './types.js';
 import { VERSION } from '../mcp-server/config.js';
@@ -85,6 +86,18 @@ type RouteBody = {
   recordEvent?: boolean;
   include_preflight?: boolean;
   includePreflight?: boolean;
+  receipt_id?: string;
+  receiptId?: string;
+  input?: unknown;
+  output?: unknown;
+  outcome?: EventOutcome;
+  error_summary?: string;
+  errorSummary?: string;
+  metadata?: Record<string, unknown>;
+  retain_details?: boolean;
+  retainDetails?: boolean;
+  evidence_feedback?: Record<string, 'used' | 'helpful' | 'wrong'>;
+  evidenceFeedback?: Record<string, 'used' | 'helpful' | 'wrong'>;
 };
 
 function actionFromBody(body: RouteBody): unknown {
@@ -311,6 +324,59 @@ export function createApp(audrey: Audrey, options: AppOptions = {}): Hono {
       return c.json(result);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: message }, 400);
+    }
+  });
+
+  // POST /v1/guard/before
+  app.post('/v1/guard/before', async (c) => {
+    try {
+      const body = await c.req.json() as RouteBody;
+      const action = actionFromBody(body);
+      if (typeof action !== 'string' || action.trim().length === 0) {
+        return c.json({ error: 'action must be a non-empty string' }, 400);
+      }
+
+      const result = await audrey.beforeAction(action, {
+        ...preflightOptionsFromBody(body),
+        recordEvent: true,
+      });
+      return c.json(result);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: message }, 400);
+    }
+  });
+
+  // POST /v1/guard/after
+  app.post('/v1/guard/after', async (c) => {
+    try {
+      const body = await c.req.json() as RouteBody;
+      const receiptId = body.receipt_id ?? body.receiptId;
+      if (typeof receiptId !== 'string' || receiptId.trim().length === 0) {
+        return c.json({ error: 'receiptId is required' }, 400);
+      }
+
+      const result = audrey.afterAction({
+        receiptId,
+        tool: body.tool,
+        sessionId: body.session_id ?? body.sessionId,
+        input: body.input,
+        output: body.output,
+        outcome: body.outcome,
+        errorSummary: body.error_summary ?? body.errorSummary,
+        cwd: body.cwd,
+        files: body.files,
+        metadata: body.metadata,
+        retainDetails: body.retain_details ?? body.retainDetails,
+        evidenceFeedback: body.evidence_feedback ?? body.evidenceFeedback,
+      });
+      return c.json(result);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (/guard receipt not found/i.test(message)) {
+        return c.json({ error: message }, 404);
+      }
       return c.json({ error: message }, 400);
     }
   });

--- a/tests/benchmarks.test.js
+++ b/tests/benchmarks.test.js
@@ -19,10 +19,13 @@ describe('benchmark suite', () => {
 
     expect(summary.local.overall.length).toBeGreaterThanOrEqual(4);
     expect(summary.local.overall[0].system).toBe('Audrey');
-    expect(summary.local.suites.map(suite => suite.id)).toEqual(['retrieval', 'operations']);
+    expect(summary.local.overall_scope).toBe('comparable_suites');
+    expect(summary.local.overall_suite_ids).toEqual(['retrieval', 'operations']);
+    expect(summary.local.suites.map(suite => suite.id)).toEqual(['retrieval', 'operations', 'guard']);
     expect(summary.external.leaderboard[0].system).toBe('MIRIX');
     expect(summary.local.cases.some(testCase => testCase.id === 'procedural-learning')).toBe(true);
     expect(summary.local.cases.some(testCase => testCase.id === 'operation-semantic-merge')).toBe(true);
+    expect(summary.local.cases.some(testCase => testCase.id === 'guard-recent-tool-failure')).toBe(true);
   });
 
   it('writes JSON, HTML, and SVG artifacts', async () => {
@@ -58,6 +61,34 @@ describe('benchmark suite', () => {
     expect(summary.local.suites).toHaveLength(1);
     expect(summary.local.suites[0].id).toBe('operations');
     expect(summary.local.cases.every(testCase => testCase.suite === 'operations')).toBe(true);
+  });
+
+  it('scores the Audrey Guard closed-loop controller as its own benchmark suite', async () => {
+    const summary = await runBenchmarkSuite({ provider: 'mock', dimensions: 64, suite: 'guard' });
+
+    expect(summary.config.suites).toEqual(['guard']);
+    expect(summary.local.overall_scope).toBe('selected_suites');
+    expect(summary.local.overall_suite_ids).toEqual(['guard']);
+    expect(summary.local.suites).toHaveLength(1);
+    expect(summary.local.suites[0].id).toBe('guard');
+    expect(summary.local.cases.map(testCase => testCase.id)).toEqual([
+      'guard-recent-tool-failure',
+      'guard-strict-must-follow',
+    ]);
+
+    const audrey = summary.local.overall.find(row => row.system === 'Audrey');
+    expect(audrey?.scorePercent).toBe(100);
+    expect(audrey?.passRate).toBe(100);
+
+    const strongestBaseline = summary.local.overall.find(row => row.system !== 'Audrey');
+    expect(strongestBaseline?.scorePercent).toBe(0);
+
+    for (const caseResult of summary.local.cases) {
+      const audreyResult = caseResult.results.find(result => result.system === 'Audrey');
+      expect(audreyResult?.passed).toBe(true);
+      expect(audreyResult?.topResults.join('\n')).toMatch(/decision:(caution|block)/);
+      expect(audreyResult?.topResults.join('\n')).toMatch(/reflex:(warn|block)/);
+    }
   });
 
   it('enforces benchmark regression guardrails', async () => {

--- a/tests/controller.test.js
+++ b/tests/controller.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, rmSync, mkdirSync } from 'node:fs';
+import { Audrey } from '../dist/src/index.js';
+
+const TEST_DIR = './test-controller-data';
+
+function metadataOf(event) {
+  return event.metadata ? JSON.parse(event.metadata) : {};
+}
+
+describe('Audrey Guard controller', () => {
+  let audrey;
+
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    audrey = new Audrey({
+      dataDir: TEST_DIR,
+      agent: 'controller-test',
+      embedding: { provider: 'mock', dimensions: 8 },
+    });
+  });
+
+  afterEach(() => {
+    audrey.close();
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  });
+
+  it('beforeAction returns go and records one receipt when no warnings exist', async () => {
+    const result = await audrey.beforeAction('format docs', {
+      tool: 'Bash',
+      sessionId: 'S-1',
+      includeCapsule: false,
+    });
+
+    expect(result.decision).toBe('go');
+    expect(result.ok_to_proceed).toBe(true);
+    expect(result.receipt_id).toMatch(/^01/);
+    expect(result.preflight_event_id).toBe(result.receipt_id);
+    expect(result.reflexes).toEqual([]);
+
+    const events = audrey.listEvents({ eventType: 'PreToolUse', toolName: 'Bash' });
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe(result.receipt_id);
+    expect(metadataOf(events[0]).guard).toBe(true);
+  });
+
+  it('beforeAction blocks strict high-severity memory and returns blocking reflexes', async () => {
+    await audrey.encode({
+      content: 'Never publish Audrey without running npm pack --dry-run first.',
+      source: 'direct-observation',
+      tags: ['must-follow', 'release'],
+    });
+
+    const result = await audrey.beforeAction('publish Audrey release', {
+      tool: 'npm publish',
+      strict: true,
+      includeCapsule: false,
+    });
+
+    expect(result.decision).toBe('block');
+    expect(result.ok_to_proceed).toBe(false);
+    expect(result.reflexes.some(r => r.response_type === 'block')).toBe(true);
+    expect(result.evidence_ids.some(id => !id.startsWith('failure:'))).toBe(true);
+  });
+
+  it('afterAction links the post event to the beforeAction receipt metadata', async () => {
+    const before = await audrey.beforeAction('run unit tests', {
+      tool: 'npm test',
+      sessionId: 'S-2',
+      includeCapsule: false,
+    });
+
+    const after = audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'npm test',
+      sessionId: 'S-2',
+      outcome: 'succeeded',
+      output: 'all tests passed\nraw details',
+    });
+
+    expect(after.receipt_id).toBe(before.receipt_id);
+    expect(after.post_event_id).toMatch(/^01/);
+    expect(after.outcome).toBe('succeeded');
+
+    const events = audrey.listEvents({ eventType: 'PostToolUse', toolName: 'npm test' });
+    expect(events).toHaveLength(1);
+    expect(events[0].session_id).toBe('S-2');
+    expect(metadataOf(events[0]).preflight_event_id).toBe(before.receipt_id);
+    expect(metadataOf(events[0]).guard).toBe(true);
+    expect(metadataOf(events[0]).output_summary).toBe('all tests passed');
+    expect(metadataOf(events[0]).redacted_output).toBeUndefined();
+  });
+
+  it('afterAction failure becomes a recent-failure warning on the next guard check', async () => {
+    const before = await audrey.beforeAction('run npm test', {
+      tool: 'npm test',
+      includeCapsule: false,
+    });
+
+    audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'npm test',
+      outcome: 'failed',
+      errorSummary: 'Vitest failed with spawn EPERM',
+    });
+
+    const next = await audrey.beforeAction('run npm test before release', {
+      tool: 'npm test',
+      includeCapsule: false,
+    });
+
+    expect(next.decision).toBe('caution');
+    expect(next.warnings.some(w => w.type === 'recent_failure')).toBe(true);
+  });
+
+  it('afterAction validates real evidence ids and skips synthetic failure ids', async () => {
+    const memoryId = await audrey.encode({
+      content: 'Never deploy without package tarball inspection.',
+      source: 'direct-observation',
+      tags: ['must-follow', 'release'],
+      salience: 0.5,
+    });
+    audrey.observeTool({
+      event: 'PostToolUse',
+      tool: 'deploy',
+      outcome: 'failed',
+      errorSummary: 'deploy failed before',
+    });
+
+    const before = await audrey.beforeAction('deploy Audrey release', {
+      tool: 'deploy',
+      strict: true,
+      includeCapsule: false,
+    });
+
+    const after = audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'deploy',
+      outcome: 'blocked',
+      evidenceFeedback: Object.fromEntries(before.evidence_ids.map(id => [id, 'helpful'])),
+    });
+
+    expect(after.validated_evidence.some(v => v.id === memoryId && v.validated)).toBe(true);
+    expect(after.validated_evidence.some(v => v.id.startsWith('failure:') && !v.validated)).toBe(true);
+
+    const impact = audrey.impact();
+    expect(impact.validatedTotal).toBe(1);
+    expect(impact.outcomeBreakdownInWindow.helpful).toBe(1);
+  });
+});

--- a/tests/controller.test.js
+++ b/tests/controller.test.js
@@ -205,6 +205,69 @@ describe('Audrey Guard controller', () => {
     expect(impact.outcomeBreakdownInWindow.helpful).toBe(1);
   });
 
+  it('afterAction rejects invalid evidence feedback outcomes before validation mutates memory', async () => {
+    const memoryId = await audrey.encode({
+      content: 'Never deploy Audrey without package tarball inspection.',
+      source: 'direct-observation',
+      tags: ['must-follow', 'release'],
+      salience: 0.5,
+    });
+    const before = await audrey.beforeAction('deploy Audrey release', {
+      tool: 'deploy',
+      strict: true,
+      includeCapsule: false,
+    });
+
+    expect(() => audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'deploy',
+      outcome: 'blocked',
+      evidenceFeedback: {
+        [memoryId]: 'bogus',
+      },
+    })).toThrow(/invalid evidence feedback/i);
+
+    const impact = audrey.impact();
+    expect(impact.validatedTotal).toBe(0);
+  });
+
+  it('afterAction only accepts guard receipts', () => {
+    const preTool = audrey.observeTool({
+      event: 'PreToolUse',
+      tool: 'npm test',
+      outcome: 'unknown',
+    }).event;
+
+    expect(() => audrey.afterAction({
+      receiptId: preTool.id,
+      tool: 'npm test',
+      outcome: 'succeeded',
+    })).toThrow(/not a guard receipt/i);
+  });
+
+  it('afterAction rejects replay for a receipt that already has an outcome', async () => {
+    const before = await audrey.beforeAction('run unit tests', {
+      tool: 'npm test',
+      includeCapsule: false,
+    });
+
+    audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'npm test',
+      outcome: 'succeeded',
+    });
+
+    expect(() => audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'npm test',
+      outcome: 'failed',
+      errorSummary: 'replayed failure',
+    })).toThrow(/already has an outcome/i);
+
+    expect(audrey.listEvents({ eventType: 'PostToolUse', toolName: 'npm test' })).toHaveLength(1);
+    expect(audrey.listEvents({ eventType: 'PostToolUseFailure', toolName: 'npm test' })).toHaveLength(0);
+  });
+
   it('afterAction records failed outcomes as PostToolUseFailure and default outcomes as PostToolUse', async () => {
     const failedBefore = await audrey.beforeAction('run failing command', {
       tool: 'npm test',
@@ -252,21 +315,18 @@ describe('Audrey Guard controller', () => {
     expect(afterEvents[0].post_event_id).toBe(after.post_event_id);
   });
 
-  it('afterAction treats malformed receipt metadata as empty metadata', async () => {
+  it('afterAction rejects malformed receipt metadata because it cannot verify a guard receipt', async () => {
     const before = await audrey.beforeAction('run unit tests', {
       tool: 'npm test',
       includeCapsule: false,
     });
     audrey.db.prepare('UPDATE memory_events SET metadata = ? WHERE id = ?').run('{not-json', before.receipt_id);
 
-    const after = audrey.afterAction({
+    expect(() => audrey.afterAction({
       receiptId: before.receipt_id,
       tool: 'npm test',
       outcome: 'succeeded',
-    });
-
-    expect(after.outcome).toBe('succeeded');
-    expect(audrey.listEvents({ eventType: 'PostToolUse', toolName: 'npm test' })).toHaveLength(1);
+    })).toThrow(/not a guard receipt/i);
   });
 
   it('afterAction finds receipts outside the recent event list limit', async () => {

--- a/tests/controller.test.js
+++ b/tests/controller.test.js
@@ -28,7 +28,6 @@ describe('Audrey Guard controller', () => {
 
   it('beforeAction returns go and records one receipt when no warnings exist', async () => {
     const result = await audrey.beforeAction('format docs', {
-      tool: 'Bash',
       sessionId: 'S-1',
       includeCapsule: false,
     });
@@ -39,10 +38,17 @@ describe('Audrey Guard controller', () => {
     expect(result.preflight_event_id).toBe(result.receipt_id);
     expect(result.reflexes).toEqual([]);
 
-    const events = audrey.listEvents({ eventType: 'PreToolUse', toolName: 'Bash' });
+    const events = audrey.listEvents({ eventType: 'PreToolUse', toolName: 'guard' });
     expect(events).toHaveLength(1);
     expect(events[0].id).toBe(result.receipt_id);
-    expect(metadataOf(events[0]).guard).toBe(true);
+    expect(events[0].tool_name).toBe('guard');
+    const metadata = metadataOf(events[0]);
+    expect(metadata.guard).toBe(true);
+    expect(metadata.guard_phase).toBe('before');
+    expect(metadata.evidence_ids).toEqual([]);
+    expect(metadata.reflex_ids).toEqual([]);
+    expect(metadata.preflight_decision).toBe('go');
+    expect(metadata.preflight_warning_count).toBe(0);
   });
 
   it('beforeAction blocks strict high-severity memory and returns blocking reflexes', async () => {
@@ -88,6 +94,10 @@ describe('Audrey Guard controller', () => {
     expect(events[0].session_id).toBe('S-2');
     expect(metadataOf(events[0]).preflight_event_id).toBe(before.receipt_id);
     expect(metadataOf(events[0]).guard).toBe(true);
+    expect(metadataOf(events[0]).guard_phase).toBe('after');
+    expect(metadataOf(events[0]).receipt_id).toBe(before.receipt_id);
+    expect(metadataOf(events[0]).preflight_decision).toBe('go');
+    expect(metadataOf(events[0]).preflight_warning_count).toBe(0);
     expect(metadataOf(events[0]).output_summary).toBe('all tests passed');
     expect(metadataOf(events[0]).redacted_output).toBeUndefined();
   });
@@ -147,5 +157,138 @@ describe('Audrey Guard controller', () => {
     const impact = audrey.impact();
     expect(impact.validatedTotal).toBe(1);
     expect(impact.outcomeBreakdownInWindow.helpful).toBe(1);
+  });
+
+  it('afterAction rejects feedback outside receipt evidence', async () => {
+    const receiptMemoryId = await audrey.encode({
+      content: 'Never deploy Audrey without package tarball inspection.',
+      source: 'direct-observation',
+      tags: ['must-follow', 'release'],
+      salience: 0.5,
+    });
+    const before = await audrey.beforeAction('deploy Audrey release', {
+      tool: 'deploy',
+      strict: true,
+      includeCapsule: false,
+    });
+    const unrelatedMemoryId = await audrey.encode({
+      content: 'The user prefers compact status updates in the morning.',
+      source: 'direct-observation',
+      salience: 0.5,
+    });
+
+    expect(before.evidence_ids).toContain(receiptMemoryId);
+    expect(before.evidence_ids).not.toContain(unrelatedMemoryId);
+
+    const after = audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'deploy',
+      outcome: 'blocked',
+      evidenceFeedback: {
+        [receiptMemoryId]: 'helpful',
+        [unrelatedMemoryId]: 'helpful',
+      },
+    });
+
+    expect(after.validated_evidence).toContainEqual(expect.objectContaining({
+      id: receiptMemoryId,
+      validated: true,
+    }));
+    expect(after.validated_evidence).toContainEqual(expect.objectContaining({
+      id: unrelatedMemoryId,
+      validated: false,
+    }));
+    expect(after.validated_evidence.find(v => v.id === unrelatedMemoryId)?.reason).toMatch(/receipt evidence/i);
+
+    const impact = audrey.impact();
+    expect(impact.validatedTotal).toBe(1);
+    expect(impact.outcomeBreakdownInWindow.helpful).toBe(1);
+  });
+
+  it('afterAction records failed outcomes as PostToolUseFailure and default outcomes as PostToolUse', async () => {
+    const failedBefore = await audrey.beforeAction('run failing command', {
+      tool: 'npm test',
+      includeCapsule: false,
+    });
+    const unknownBefore = await audrey.beforeAction('run command with unknown result', {
+      tool: 'node script.js',
+      includeCapsule: false,
+    });
+
+    const failed = audrey.afterAction({
+      receiptId: failedBefore.receipt_id,
+      tool: 'npm test',
+      outcome: 'failed',
+      errorSummary: 'tests failed',
+    });
+    const unknown = audrey.afterAction({
+      receiptId: unknownBefore.receipt_id,
+      tool: 'node script.js',
+    });
+
+    expect(failed.outcome).toBe('failed');
+    expect(unknown.outcome).toBe('unknown');
+    expect(audrey.listEvents({ eventType: 'PostToolUseFailure', toolName: 'npm test' })).toHaveLength(1);
+    expect(audrey.listEvents({ eventType: 'PostToolUse', toolName: 'node script.js' })).toHaveLength(1);
+  });
+
+  it('emits guard-before and guard-after events', async () => {
+    const beforeEvents = [];
+    const afterEvents = [];
+    audrey.on('guard-before', event => beforeEvents.push(event));
+    audrey.on('guard-after', event => afterEvents.push(event));
+
+    const before = await audrey.beforeAction('format docs', {
+      includeCapsule: false,
+    });
+    const after = audrey.afterAction({
+      receiptId: before.receipt_id,
+      outcome: 'succeeded',
+    });
+
+    expect(beforeEvents).toHaveLength(1);
+    expect(beforeEvents[0].receipt_id).toBe(before.receipt_id);
+    expect(afterEvents).toHaveLength(1);
+    expect(afterEvents[0].post_event_id).toBe(after.post_event_id);
+  });
+
+  it('afterAction treats malformed receipt metadata as empty metadata', async () => {
+    const before = await audrey.beforeAction('run unit tests', {
+      tool: 'npm test',
+      includeCapsule: false,
+    });
+    audrey.db.prepare('UPDATE memory_events SET metadata = ? WHERE id = ?').run('{not-json', before.receipt_id);
+
+    const after = audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'npm test',
+      outcome: 'succeeded',
+    });
+
+    expect(after.outcome).toBe('succeeded');
+    expect(audrey.listEvents({ eventType: 'PostToolUse', toolName: 'npm test' })).toHaveLength(1);
+  });
+
+  it('afterAction finds receipts outside the recent event list limit', async () => {
+    const before = await audrey.beforeAction('run old receipt command', {
+      tool: 'old-tool',
+      includeCapsule: false,
+    });
+    for (let i = 0; i < 1001; i += 1) {
+      audrey.observeTool({
+        event: 'PreToolUse',
+        tool: `newer-tool-${i}`,
+        outcome: 'unknown',
+      });
+    }
+
+    const after = audrey.afterAction({
+      receiptId: before.receipt_id,
+      tool: 'old-tool',
+      outcome: 'succeeded',
+    });
+
+    expect(after.receipt_id).toBe(before.receipt_id);
+    expect(after.post_event_id).toMatch(/^01/);
   });
 });

--- a/tests/http-api.test.js
+++ b/tests/http-api.test.js
@@ -6,6 +6,10 @@ import { Audrey } from '../dist/src/index.js';
 
 const TEST_DIR = './test-http-data';
 
+function metadataOf(event) {
+  return event.metadata ? JSON.parse(event.metadata) : {};
+}
+
 describe('HTTP API', () => {
   let audrey, app;
 
@@ -148,6 +152,107 @@ describe('HTTP API', () => {
     expect(body.reflexes[0].trigger).toBe('Before using npm test');
     expect(body.reflexes[0].response_type).toBe('warn');
     expect(body.preflight.decision).toBe('caution');
+  });
+
+  it('POST /v1/guard/before returns caution receipt, reflexes, and recent failure warning', async () => {
+    audrey.observeTool({
+      event: 'PostToolUse',
+      tool: 'npm test',
+      outcome: 'failed',
+      errorSummary: 'Vitest failed with spawn EPERM on this host',
+      cwd: process.cwd(),
+    });
+
+    const res = await app.request('/v1/guard/before', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action: 'run npm test before release',
+        tool: 'npm test',
+        include_capsule: false,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.receipt_id).toMatch(/^01/);
+    expect(body.decision).toBe('caution');
+    expect(body.reflexes[0].trigger).toBe('Before using npm test');
+    expect(body.warnings.some(w => w.type === 'recent_failure')).toBe(true);
+  });
+
+  it('POST /v1/guard/before rejects blank action', async () => {
+    const res = await app.request('/v1/guard/before', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: '   ' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/action/i);
+  });
+
+  it('POST /v1/guard/after records a redacted failed outcome linked to receipt', async () => {
+    const rawToken = 'sk-proj-abcdefghijklmnopqrstuvwxyz123456';
+    const beforeRes = await app.request('/v1/guard/before', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action: 'run npm test',
+        tool: 'npm test',
+        session_id: 'S-http-guard',
+        include_capsule: false,
+      }),
+    });
+    expect(beforeRes.status).toBe(200);
+    const before = await beforeRes.json();
+
+    const afterRes = await app.request('/v1/guard/after', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        receipt_id: before.receipt_id,
+        tool: 'npm test',
+        session_id: 'S-http-guard',
+        outcome: 'failed',
+        error_summary: `Vitest failed while using ${rawToken}`,
+        metadata: { route: 'http-test' },
+        unsafe_extra_field: rawToken,
+      }),
+    });
+
+    expect(afterRes.status).toBe(200);
+    const body = await afterRes.json();
+    expect(JSON.stringify(body)).not.toContain(rawToken);
+    expect(body.receipt_id).toBe(before.receipt_id);
+    expect(body.outcome).toBe('failed');
+
+    const events = audrey.listEvents({ eventType: 'PostToolUseFailure', toolName: 'npm test' });
+    expect(events).toHaveLength(1);
+    expect(events[0].session_id).toBe('S-http-guard');
+    expect(events[0].outcome).toBe('failed');
+    expect(events[0].redaction_state).toBe('redacted');
+    expect(events[0].error_summary).not.toContain(rawToken);
+    expect(events[0].error_summary).toContain('[REDACTED:openai_api_key');
+    expect(metadataOf(events[0]).receipt_id).toBe(before.receipt_id);
+    expect(JSON.stringify(metadataOf(events[0]))).not.toContain(rawToken);
+  });
+
+  it('POST /v1/guard/after returns 404 for unknown receipt', async () => {
+    const res = await app.request('/v1/guard/after', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        receipt_id: '01UNKNOWNRECEIPT000000000000',
+        outcome: 'failed',
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body.error).toMatch(/receipt/i);
   });
 
   it('POST /v1/dream runs full cycle', async () => {

--- a/tests/http-api.test.js
+++ b/tests/http-api.test.js
@@ -255,6 +255,44 @@ describe('HTTP API', () => {
     expect(body.error).toMatch(/receipt/i);
   });
 
+  it('POST /v1/guard/after rejects invalid evidence feedback outcomes', async () => {
+    const memoryId = await audrey.encode({
+      content: 'Never deploy Audrey without package tarball inspection.',
+      source: 'direct-observation',
+      tags: ['must-follow', 'release'],
+      salience: 0.5,
+    });
+    const beforeRes = await app.request('/v1/guard/before', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action: 'deploy Audrey release',
+        tool: 'deploy',
+        strict: true,
+        include_capsule: false,
+      }),
+    });
+    expect(beforeRes.status).toBe(200);
+    const before = await beforeRes.json();
+
+    const res = await app.request('/v1/guard/after', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        receipt_id: before.receipt_id,
+        outcome: 'blocked',
+        evidence_feedback: {
+          [memoryId]: 'bogus',
+        },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid evidence feedback/i);
+    expect(audrey.impact().validatedTotal).toBe(0);
+  });
+
   it('POST /v1/dream runs full cycle', async () => {
     const res = await app.request('/v1/dream', {
       method: 'POST',

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -59,12 +59,20 @@ describe('CLI surface', () => {
   // dropped the user into an MCP stdio server waiting on stdin.
   const cli = resolve('dist/mcp-server/index.js');
 
+  afterEach(() => {
+    for (const dir of ['./test-cli-guard', './test-cli-guard-after']) {
+      if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('--help prints help and exits 0', () => {
     const r = spawnSync(process.execPath, [cli, '--help'], { encoding: 'utf8', timeout: 10000 });
     expect(r.status).toBe(0);
     expect(r.stdout).toContain('Usage: audrey');
     expect(r.stdout).toContain('doctor');
     expect(r.stdout).toContain('demo');
+    expect(r.stdout).toContain('guard');
+    expect(r.stdout).toContain('guard-after');
   });
 
   it('--version prints version and exits 0', () => {
@@ -78,6 +86,41 @@ describe('CLI surface', () => {
     expect(r.status).toBe(2);
     expect(r.stderr).toContain("unknown command 'definitelynotacommand'");
     expect(r.stdout).toContain('Usage: audrey');
+  });
+
+  it('guard --json emits a before-action decision', () => {
+    const r = spawnSync(
+      process.execPath,
+      [cli, 'guard', '--json', '--tool', 'Bash', 'list files before editing'],
+      {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: {
+          ...process.env,
+          AUDREY_DATA_DIR: './test-cli-guard',
+          AUDREY_EMBEDDING_PROVIDER: 'mock',
+        },
+      },
+    );
+    expect(r.status).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.receipt_id).toMatch(/^01/);
+    expect(parsed.decision).toBe('go');
+    expect(Array.isArray(parsed.evidence_ids)).toBe(true);
+  });
+
+  it('guard exits 2 when action is missing', () => {
+    const r = spawnSync(process.execPath, [cli, 'guard'], {
+      encoding: 'utf8',
+      timeout: 10000,
+      env: {
+        ...process.env,
+        AUDREY_DATA_DIR: './test-cli-guard',
+        AUDREY_EMBEDDING_PROVIDER: 'mock',
+      },
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('[audrey] guard: action is required');
   });
 });
 

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -72,6 +72,7 @@ describe('CLI surface', () => {
     expect(r.stdout).toContain('doctor');
     expect(r.stdout).toContain('demo');
     expect(r.stdout).toContain('guard');
+    expect(r.stdout).toContain('guard-after');
   });
 
   it('--version prints version and exits 0', () => {
@@ -120,6 +121,60 @@ describe('CLI surface', () => {
     });
     expect(r.status).toBe(2);
     expect(r.stderr).toContain('[audrey] guard: action is required');
+  });
+
+  it('guard-after records an action outcome from hook-shaped stdin', () => {
+    const env = {
+      ...process.env,
+      AUDREY_DATA_DIR: './test-cli-guard-after',
+      AUDREY_EMBEDDING_PROVIDER: 'mock',
+    };
+    const before = spawnSync(
+      process.execPath,
+      [cli, 'guard', '--json', '--tool', 'Bash', 'run a safe command'],
+      {
+        encoding: 'utf8',
+        timeout: 10000,
+        env,
+      },
+    );
+    expect(before.status).toBe(0);
+    const receipt = JSON.parse(before.stdout);
+
+    const after = spawnSync(
+      process.execPath,
+      [cli, 'guard-after', '--receipt', receipt.receipt_id],
+      {
+        input: JSON.stringify({
+          hook_event_name: 'PostToolUse',
+          tool_name: 'Bash',
+          session_id: 'S-cli',
+          tool_response: { success: true, stdout: 'ok' },
+        }),
+        encoding: 'utf8',
+        timeout: 10000,
+        env,
+      },
+    );
+    expect(after.status).toBe(0);
+    const parsed = JSON.parse(after.stdout);
+    expect(parsed.receipt_id).toBe(receipt.receipt_id);
+    expect(parsed.post_event_id).toMatch(/^01/);
+    expect(parsed.outcome).toBe('succeeded');
+  });
+
+  it('guard-after exits 2 when receipt is missing', () => {
+    const r = spawnSync(process.execPath, [cli, 'guard-after'], {
+      encoding: 'utf8',
+      timeout: 10000,
+      env: {
+        ...process.env,
+        AUDREY_DATA_DIR: './test-cli-guard-after',
+        AUDREY_EMBEDDING_PROVIDER: 'mock',
+      },
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('[audrey] guard-after: --receipt is required');
   });
 });
 

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -28,6 +28,8 @@ import {
   memoryForgetToolSchema,
   memoryValidateToolSchema,
   memoryImportToolSchema,
+  memoryGuardAfterToolSchema,
+  memoryGuardBeforeToolSchema,
   memoryPreflightToolSchema,
   memoryRecallToolSchema,
   memoryReflexesToolSchema,
@@ -368,6 +370,53 @@ describe('MCP validation hardening', () => {
       record_event: true,
       include_capsule: false,
     }).success).toBe(true);
+  });
+
+  it('memory_guard_before rejects empty actions and accepts preflight-style strict options', () => {
+    const schema = z.object(memoryGuardBeforeToolSchema);
+    expect(schema.safeParse({ action: '', tool: 'Bash' }).success).toBe(false);
+    expect(schema.safeParse({
+      action: 'run npm test',
+      tool: 'npm test',
+      session_id: 'session-1',
+      cwd: '/tmp/audrey',
+      files: ['package.json'],
+      strict: true,
+      limit: 8,
+      budget_chars: 1000,
+      mode: 'conservative',
+      failure_window_hours: 24,
+      include_status: true,
+      record_event: false,
+      include_capsule: false,
+      scope: 'shared',
+    }).success).toBe(true);
+  });
+
+  it('memory_guard_after accepts observe-tool outcomes with evidence feedback', () => {
+    const schema = z.object(memoryGuardAfterToolSchema);
+    expect(schema.safeParse({
+      receipt_id: 'receipt-1',
+      tool: 'Bash',
+      session_id: 'session-1',
+      input: { command: 'npm test' },
+      output: { exitCode: 0 },
+      outcome: 'succeeded',
+      error_summary: 'none',
+      cwd: '/tmp/audrey',
+      files: ['package.json'],
+      metadata: { task: 'guard' },
+      retain_details: true,
+      evidence_feedback: {
+        'ep-1': 'used',
+        'sem-1': 'helpful',
+        'proc-1': 'wrong',
+      },
+    }).success).toBe(true);
+    expect(schema.safeParse({
+      receipt_id: 'receipt-1',
+      outcome: 'maybe',
+    }).success).toBe(false);
   });
 
   it('memory_reflexes accepts preflight inputs plus include_preflight', () => {

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -72,7 +72,6 @@ describe('CLI surface', () => {
     expect(r.stdout).toContain('doctor');
     expect(r.stdout).toContain('demo');
     expect(r.stdout).toContain('guard');
-    expect(r.stdout).toContain('guard-after');
   });
 
   it('--version prints version and exits 0', () => {

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -471,6 +471,7 @@ describe('MCP validation hardening', () => {
 
   it('memory_guard_before rejects empty actions and accepts preflight-style strict options', () => {
     const schema = z.object(memoryGuardBeforeToolSchema);
+    expect(memoryGuardBeforeToolSchema).not.toHaveProperty('record_event');
     expect(schema.safeParse({ action: '', tool: 'Bash' }).success).toBe(false);
     expect(schema.safeParse({
       action: 'run npm test',
@@ -484,7 +485,6 @@ describe('MCP validation hardening', () => {
       mode: 'conservative',
       failure_window_hours: 24,
       include_status: true,
-      record_event: false,
       include_capsule: false,
       scope: 'shared',
     }).success).toBe(true);

--- a/tests/reflexes.test.js
+++ b/tests/reflexes.test.js
@@ -61,4 +61,26 @@ describe('Memory Reflexes', () => {
     expect(report.preflight.decision).toBe('block');
     expect(report.evidence_ids.length).toBeGreaterThan(0);
   });
+
+  it('builds reflexes from an existing preflight without running preflight again', async () => {
+    await audrey.encode({
+      content: 'Never deploy Audrey without checking the package tarball first.',
+      source: 'direct-observation',
+      tags: ['must-follow', 'release'],
+    });
+
+    const preflight = await audrey.preflight('deploy Audrey release', {
+      strict: true,
+    });
+    const { buildReflexReportFromPreflight } = await import('../dist/src/reflexes.js');
+
+    const report = buildReflexReportFromPreflight(preflight, {
+      includePreflight: true,
+    });
+
+    expect(report.decision).toBe('block');
+    expect(report.reflexes.some(r => r.response_type === 'block')).toBe(true);
+    expect(report.preflight).toBe(preflight);
+    expect(report.evidence_ids).toEqual(preflight.evidence_ids);
+  });
 });


### PR DESCRIPTION
## Summary

This PR prepares Audrey `0.23.0` as the Audrey Guard release.

- Makes `beforeAction()` / `afterAction()` the release headline across SDK, REST, MCP, and CLI surfaces.
- Aligns version surfaces across npm, MCP CLI config, package-lock, and Python client metadata.
- Expands the Agent Guard Loop benchmark to cover prior tool-failure caution, strict must-follow blocking, replay rejection, and non-guard receipt rejection.
- Adds `benchmarks/snapshots/perf-0.23.0.json`, direct perf-snapshot version provenance, and a benchmark policy doc.
- Includes benchmark harness files in the npm tarball so advertised benchmark scripts work after publish.
- Adds `scripts/smoke-cli.js` and wires it into release gate and Node CI jobs for `--version`, `doctor --json`, and `demo` smoke evidence.
- Fixes Python 3.9 packaging by adding the `eval-type-backport` marker and updates Python license metadata for current setuptools.

## Verification

- `npm run release:gate`
  - typecheck passed
  - perf gate passed: encode p95 `0.428ms`, hybrid recall p95 `0.801ms`, queue p50 `0.094ms`
  - Vitest: `42 passed | 1 skipped`, `680 passed | 14 skipped`
  - memory regression gate: `16` cases total, `12` comparable local cases, Audrey `100.0%`, margin over Vector Only `58.3` points
  - CLI smoke passed for `0.23.0`
  - npm pack dry-run produced `audrey-0.23.0.tgz` with benchmark files and `scripts/smoke-cli.js`
- `python/.venv/bin/python -m unittest discover -s python/tests -v`
  - `5` tests passed
- `python/.venv/bin/python -m build --no-isolation python`
  - built `audrey_memory-0.23.0.tar.gz` and `audrey_memory-0.23.0-py3-none-any.whl`

Direct pushes to `master` are still blocked by repository rules, so this updates the existing release PR branch.