### PR TITLE
Record arXiv on-hold submission state

### DIFF
--- a/docs/paper/browser-launch-results.json
+++ b/docs/paper/browser-launch-results.json
@@ -14,8 +14,8 @@
       "operatorVerified": false,
       "manualRuleCheckCompleted": true,
       "postSubmitChecksCompleted": [],
-      "blocker": "arXiv accepted the paper into the submission queue as submit/7591154, but the account page currently shows status processing and no public arXiv identifier or public abstract URL has been assigned yet.",
-      "notes": "arXiv support confirmed the active username is Evilands and suspended the duplicate account. The active account was recovered, START NEW SUBMISSION appeared, the verified source package was uploaded, arXiv TeX Live 2025 compiled main.tex to a 34-page PDF successfully, the PDF and HTML previews were opened, metadata was saved with primary category cs.AI and cross-list cs.CR, and the article was submitted on 2026-05-13. Record the final public arXiv URL after processing and announcement."
+      "blocker": "arXiv accepted the paper as submit/7591154, but the account page currently shows status on hold, so no public arXiv identifier or public abstract URL has been assigned yet.",
+      "notes": "arXiv support confirmed the active username is Evilands and suspended the duplicate account. The active account was recovered, START NEW SUBMISSION appeared, the verified source package was uploaded, arXiv TeX Live 2025 compiled main.tex to a 34-page PDF successfully, the PDF and HTML previews were opened, metadata was saved with primary category cs.AI and cross-list cs.CR, and the article was submitted on 2026-05-13. The account page first showed processing, then on hold after refresh; record the final public arXiv URL after moderation and announcement."
     },
     {
       "id": "hacker-news-show",


### PR DESCRIPTION
## Summary
- update browser launch evidence from arXiv `processing` to the current `on hold` account-page state
- keep the public arXiv URL unset until moderation assigns an identifier
- preserve the account-recovery and successful TeX/PDF/HTML preview evidence without overstating publication

## Validation
- prior local `npm run paper:launch-results` passed with the same evidence file shape
- this is a JSON evidence-only update; CI should still exercise the full release gates