### PR TITLE
Add trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,171 @@
+name: Publish Packages
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish
+        required: true
+        default: v1.0.0
+        type: string
+      publish_npm:
+        description: Publish the npm package
+        required: true
+        default: true
+        type: boolean
+      publish_pypi:
+        description: Publish the Python package to PyPI
+        required: true
+        default: true
+        type: boolean
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+
+concurrency:
+  group: publish-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  validate-release:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${RELEASE_TAG}" ]]; then
+            echo "Missing release tag" >&2
+            exit 1
+          fi
+          version=$(node --input-type=module -e "import fs from 'node:fs'; console.log(JSON.parse(fs.readFileSync('package.json', 'utf8')).version)")
+          python_version=$(python -c "from pathlib import Path; import re; text = Path('python/audrey_memory/_version.py').read_text(encoding='utf-8'); print(re.search(r'__version__\\s*=\\s*\"([^\"]+)\"', text).group(1))")
+          if [[ "${RELEASE_TAG}" != "v${version}" ]]; then
+            echo "Tag ${RELEASE_TAG} does not match package.json version ${version}" >&2
+            exit 1
+          fi
+          if [[ "${python_version}" != "${version}" ]]; then
+            echo "Python version ${python_version} does not match package.json version ${version}" >&2
+            exit 1
+          fi
+          echo "tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+  publish-npm:
+    name: Publish npm package
+    needs: validate-release
+    if: github.event_name == 'release' || inputs.publish_npm
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-release.outputs.tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - run: npm install -g npm@latest
+      - run: npm ci
+      - run: npm run build
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run bench:memory:check
+      - run: npm run npm:smoke
+      - run: npm run pack:check
+      - name: Verify npm version is unpublished
+        shell: bash
+        run: |
+          set -euo pipefail
+          if npm view "audrey@${{ needs.validate-release.outputs.version }}" version >/dev/null 2>&1; then
+            echo "audrey@${{ needs.validate-release.outputs.version }} is already published" >&2
+            exit 1
+          fi
+      - run: npm publish
+
+  build-python:
+    name: Build Python distributions
+    needs: validate-release
+    if: github.event_name == 'release' || inputs.publish_pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-release.outputs.tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - run: npm ci
+      - run: npm run build
+      - run: python -m pip install --upgrade pip setuptools wheel build twine
+      - run: python -m pip install -e ./python
+      - run: python -m unittest discover -s python/tests -v
+      - run: python -m build --no-isolation python
+      - run: python scripts/verify-python-package.py --version ${{ needs.validate-release.outputs.version }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: audrey-python-dist-${{ needs.validate-release.outputs.version }}
+          path: python/dist/*
+          if-no-files-found: error
+
+  publish-pypi:
+    name: Publish Python package to PyPI
+    needs:
+      - validate-release
+      - build-python
+    if: github.event_name == 'release' || inputs.publish_pypi
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: audrey-python-dist-${{ needs.validate-release.outputs.version }}
+          path: python/dist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist


### PR DESCRIPTION
## Summary
- add a manual/release-triggered package publishing workflow for Audrey 1.0+
- use tokenless npm trusted publishing with job-level `id-token: write`, Node 24, and npm latest
- use PyPI trusted publishing with a separate Python dist build job and `pypa/gh-action-pypi-publish@release/v1`
- verify the git tag matches both `package.json` and `python/audrey_memory/_version.py` before publishing
- keep npm/PyPI jobs separately toggleable for manual recovery if one registry succeeds and the other fails

## Trusted publisher setup needed
- npm package `audrey`: GitHub Actions publisher, owner `Evilander`, repo `Audrey`, workflow filename `publish.yml`, environment `npm`
- PyPI project `audrey-memory`: GitHub Actions publisher, owner `Evilander`, repo `Audrey`, workflow filename `publish.yml`, environment `pypi`

## Verification
- GitHub Actions CI will run on this PR
- Workflow structure follows current npm and PyPI trusted-publishing docs

Sources:
- https://docs.npmjs.com/trusted-publishers/
- https://docs.pypi.org/trusted-publishers/using-a-publisher/
- https://docs.pypi.org/trusted-publishers/adding-a-publisher/