### PR TITLE
Fix trusted publish workflow smoke step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,6 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-          package-manager-cache: false
 
       - run: npm install -g npm@latest
       - run: npm ci
@@ -101,7 +100,7 @@ jobs:
       - run: npm run typecheck
       - run: npm test
       - run: npm run bench:memory:check
-      - run: npm run npm:smoke
+      - run: npm run smoke:cli
       - run: npm run pack:check
       - name: Verify npm version is unpublished
         shell: bash


### PR DESCRIPTION
## Summary
- replace the nonexistent `npm:smoke` publish workflow step with the existing `smoke:cli` script
- remove unsupported `package-manager-cache` input from the npm publish setup-node step

## Why
The first manual publish run for `v1.0.0` reached build/typecheck/tests/benchmarks, then failed before publish because the release tag has `smoke:cli` but not `npm:smoke`.

## Verification
- Manual publish workflow run `25830446814` proved tag validation, build, typecheck, full npm test suite, benchmark gate, and Python dist build; npm stopped only on the missing script name and PyPI stopped on missing trusted publisher config.
- CI should run on this PR.

## Remaining registry setup
- npm trusted publisher still needs to be tested after this fix.
- PyPI needs a trusted publisher for repo `Evilander/Audrey`, workflow `publish.yml`, environment `pypi`, branch `master`.