### PR TITLE
Preserve GuardBench adapter extension evidence

### DIFF
--- a/benchmarks/guardbench.js
+++ b/benchmarks/guardbench.js
@@ -19,6 +19,16 @@ const SUBJECTS = [
   'FTS Only',
 ];
 const DECISIONS = new Set(['allow', 'warn', 'block']);
+const STANDARD_ADAPTER_RESULT_KEYS = new Set([
+  'decision',
+  'riskScore',
+  'evidenceIds',
+  'recommendedActions',
+  'summary',
+  'recallErrors',
+  'adapterExtensions',
+]);
+const RESERVED_ADAPTER_EXTENSION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 const SUBJECT_DESCRIPTIONS = {
   'Audrey Guard': 'Full Audrey pre-action MemoryController with capsule, preflight, reflex, event lineage, degradation handling, and action-key recovery.',
   'No Memory': 'Allows every proposed action without memory state, evidence, or retrieval.',
@@ -576,6 +586,71 @@ function validateStringArray(value, field, errors) {
   }
 }
 
+function isPlainJsonObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function validateJsonExtensionValue(value, field, errors) {
+  if (value === null) return;
+  if (typeof value === 'string' || typeof value === 'boolean') return;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) errors.push(`${field} must be JSON-serializable`);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      validateJsonExtensionValue(value[i], `${field}[${i}]`, errors);
+    }
+    return;
+  }
+  if (isPlainJsonObject(value)) {
+    for (const [key, nestedValue] of Object.entries(value)) {
+      if (RESERVED_ADAPTER_EXTENSION_KEYS.has(key)) {
+        errors.push(`${field}.${key} uses a reserved key`);
+        continue;
+      }
+      validateJsonExtensionValue(nestedValue, `${field}.${key}`, errors);
+    }
+    return;
+  }
+  errors.push(`${field} must be JSON-serializable`);
+}
+
+function collectAdapterExtensions(result, errors) {
+  const extensions = {};
+  const addExtension = (key, value) => {
+    if (RESERVED_ADAPTER_EXTENSION_KEYS.has(key)) {
+      errors.push(`adapter extension ${key} uses a reserved key`);
+      return;
+    }
+    validateJsonExtensionValue(value, `adapter extension ${key}`, errors);
+    extensions[key] = value;
+  };
+
+  if (result.adapterExtensions !== undefined) {
+    if (!isPlainJsonObject(result.adapterExtensions)) {
+      errors.push('adapterExtensions must be a plain object when present');
+    } else {
+      for (const [key, value] of Object.entries(result.adapterExtensions)) {
+        addExtension(key, value);
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(result)) {
+    if (STANDARD_ADAPTER_RESULT_KEYS.has(key)) continue;
+    if (Object.hasOwn(extensions, key)) {
+      errors.push(`adapterExtensions.${key} duplicates top-level adapter extension ${key}`);
+      continue;
+    }
+    addExtension(key, value);
+  }
+
+  return extensions;
+}
+
 export function validateAdapterResult(result, adapterName, scenarioId) {
   const label = `GuardBench adapter ${adapterName} returned invalid result for ${scenarioId}`;
   if (!result || typeof result !== 'object' || Array.isArray(result)) {
@@ -583,6 +658,7 @@ export function validateAdapterResult(result, adapterName, scenarioId) {
   }
 
   const errors = [];
+  const adapterExtensions = collectAdapterExtensions(result, errors);
   if (!DECISIONS.has(result.decision)) {
     errors.push('decision must be one of allow, warn, block');
   }
@@ -602,7 +678,7 @@ export function validateAdapterResult(result, adapterName, scenarioId) {
     throw new Error(`${label}: ${errors.join('; ')}`);
   }
 
-  return {
+  const normalized = {
     decision: result.decision,
     riskScore: result.riskScore,
     evidenceIds: result.evidenceIds,
@@ -610,6 +686,10 @@ export function validateAdapterResult(result, adapterName, scenarioId) {
     summary: result.summary,
     recallErrors: result.recallErrors ?? [],
   };
+  if (Object.keys(adapterExtensions).length > 0) {
+    normalized.adapterExtensions = adapterExtensions;
+  }
+  return normalized;
 }
 
 export async function loadExternalAdapters(adapterPaths = []) {
@@ -835,6 +915,7 @@ async function runScenarioForAdapter(scenario, adapter) {
       recommendedActions: normalized.recommendedActions,
       summary: normalized.summary,
       recallErrors: normalized.recallErrors,
+      ...(normalized.adapterExtensions ? { adapterExtensions: normalized.adapterExtensions } : {}),
       leakedSecrets,
       requiredEvidenceMatched: hasRequiredText,
     };

--- a/benchmarks/schemas/guardbench-raw.schema.json
+++ b/benchmarks/schemas/guardbench-raw.schema.json
@@ -25,6 +25,23 @@
     "artifactRedactionSweep": { "$ref": "#/$defs/artifactRedactionSweep" }
   },
   "$defs": {
+    "jsonValue": {
+      "anyOf": [
+        { "type": "null" },
+        { "type": "string" },
+        { "type": "boolean" },
+        { "type": "number" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/jsonValue" }
+        },
+        { "$ref": "#/$defs/jsonObject" }
+      ]
+    },
+    "jsonObject": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/jsonValue" }
+    },
     "provenance": {
       "type": "object",
       "additionalProperties": false,
@@ -129,6 +146,7 @@
         },
         "summary": { "type": "string", "minLength": 1 },
         "recallErrors": { "type": "array" },
+        "adapterExtensions": { "$ref": "#/$defs/jsonObject" },
         "leakedSecrets": {
           "type": "array",
           "items": { "type": "string" }

--- a/benchmarks/schemas/guardbench-summary.schema.json
+++ b/benchmarks/schemas/guardbench-summary.schema.json
@@ -84,6 +84,23 @@
     "artifactRedactionSweep": { "$ref": "#/$defs/artifactRedactionSweep" }
   },
   "$defs": {
+    "jsonValue": {
+      "anyOf": [
+        { "type": "null" },
+        { "type": "string" },
+        { "type": "boolean" },
+        { "type": "number" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/jsonValue" }
+        },
+        { "$ref": "#/$defs/jsonObject" }
+      ]
+    },
+    "jsonObject": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/jsonValue" }
+    },
     "latency": {
       "type": "object",
       "additionalProperties": false,
@@ -178,6 +195,7 @@
         },
         "summary": { "type": "string", "minLength": 1 },
         "recallErrors": { "type": "array" },
+        "adapterExtensions": { "$ref": "#/$defs/jsonObject" },
         "leakedSecrets": {
           "type": "array",
           "items": { "type": "string" }

--- a/tests/guardbench-adapter-extensions.test.js
+++ b/tests/guardbench-adapter-extensions.test.js
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { validateSchema } from '../benchmarks/validate-guardbench-artifacts.mjs';
+import { validateAdapterResult } from '../benchmarks/guardbench.js';
+
+const summarySchema = JSON.parse(readFileSync('benchmarks/schemas/guardbench-summary.schema.json', 'utf-8'));
+
+function adapterResult(overrides = {}) {
+  return {
+    decision: 'warn',
+    riskScore: 0.5,
+    evidenceIds: ['mem-1'],
+    recommendedActions: ['Review remembered procedure.'],
+    summary: 'Adapter found a remembered procedure.',
+    ...overrides,
+  };
+}
+
+describe('GuardBench adapter extension evidence', () => {
+  it('preserves unknown adapter fields under adapterExtensions', () => {
+    const normalized = validateAdapterResult(adapterResult({
+      probe_method: 'indirect',
+      revealed_dimensions: ['COMP', 'EXPL'],
+      gap_score: 0.42,
+    }), 'Moriarty Probe', 'GB-02');
+
+    expect(normalized.adapterExtensions).toEqual({
+      probe_method: 'indirect',
+      revealed_dimensions: ['COMP', 'EXPL'],
+      gap_score: 0.42,
+    });
+  });
+
+  it('merges explicit adapterExtensions with top-level extension fields', () => {
+    const normalized = validateAdapterResult(adapterResult({
+      adapterExtensions: {
+        probe: {
+          method: 'substrate-read',
+          dimensions: ['COMP'],
+        },
+      },
+      gap_score: 0.7,
+    }), 'Moriarty Probe', 'GB-03');
+
+    expect(normalized.adapterExtensions).toEqual({
+      probe: {
+        method: 'substrate-read',
+        dimensions: ['COMP'],
+      },
+      gap_score: 0.7,
+    });
+  });
+
+  it('rejects non-JSON extension values instead of serializing ambiguous evidence', () => {
+    expect(() => validateAdapterResult(adapterResult({
+      probe: () => null,
+    }), 'Moriarty Probe', 'GB-04')).toThrow(/adapter extension probe must be JSON-serializable/);
+
+    expect(() => validateAdapterResult(adapterResult({
+      adapterExtensions: [],
+    }), 'Moriarty Probe', 'GB-04')).toThrow(/adapterExtensions must be a plain object when present/);
+  });
+
+  it('allows extension evidence in published GuardBench result rows', () => {
+    const errors = validateSchema({
+      system: 'Moriarty Probe',
+      external: true,
+      id: 'GB-02',
+      name: 'Required preflight procedure missing',
+      expectedDecision: 'block',
+      decision: 'warn',
+      decisionCorrect: false,
+      riskScore: 0.5,
+      passed: false,
+      latencyMs: 12.3,
+      evidenceCount: 1,
+      evidenceIds: ['mem-1'],
+      recommendedActions: ['Review remembered procedure.'],
+      summary: 'Adapter surfaced a probe disagreement.',
+      recallErrors: [],
+      adapterExtensions: {
+        probe: {
+          method: 'substrate-read',
+          dimensions: ['COMP'],
+        },
+        gap_score: 0.7,
+      },
+      leakedSecrets: [],
+      requiredEvidenceMatched: true,
+    }, summarySchema.$defs.resultRow, 'resultRow', summarySchema);
+
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve adapter-specific GuardBench result fields under `adapterExtensions` instead of dropping them during normalization
- allow optional JSON-shaped `adapterExtensions` in GuardBench raw and summary schemas
- add focused tests for passthrough, explicit extension fields, non-JSON rejection, and published row schema acceptance

## Verification
- `npm ci`
- `npm run build`
- `npx vitest run tests/guardbench-adapter-extensions.test.js tests/guardbench.test.js -t "GuardBench adapter extension evidence|external adapter result contract"`
- `npm run typecheck`
- `npm run bench:guard:adapter-smoke`
- `node benchmarks/validate-guardbench-artifacts.mjs --dir benchmarks/output/adapter-smoke`