### PR TITLE
Harden CLI smoke temp directory fallback

### DIFF
--- a/scripts/smoke-cli.js
+++ b/scripts/smoke-cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -23,7 +23,27 @@ if (!existsSync(cli)) {
   fail(`missing built CLI at ${cli}; run npm run build first`);
 }
 
-const tempRoot = mkdtempSync(join(tmpdir(), 'audrey-smoke-'));
+function createTempRoot() {
+  const candidates = [
+    process.env.AUDREY_SMOKE_TMPDIR,
+    tmpdir(),
+    join(root, '.tmp'),
+  ].filter(Boolean);
+  const failures = [];
+
+  for (const candidate of candidates) {
+    try {
+      mkdirSync(candidate, { recursive: true });
+      return mkdtempSync(join(candidate, 'audrey-smoke-'));
+    } catch (error) {
+      failures.push(`${candidate}: ${error.code ?? error.message}`);
+    }
+  }
+
+  fail(`unable to create smoke temp directory (${failures.join('; ')})`);
+}
+
+const tempRoot = createTempRoot();
 const env = {
   ...process.env,
   AUDREY_DATA_DIR: join(tempRoot, 'store'),


### PR DESCRIPTION
## Summary
- make `scripts/smoke-cli.js` try `AUDREY_SMOKE_TMPDIR`, the OS temp directory, then a repo-local `.tmp` fallback
- keep the smoke command usable on hosts where `%TEMP%` points at a stale or inaccessible path
- preserve the existing CLI checks and cleanup behavior

## Verification
- Fresh checkout at `b8fa7b657047ea6c88847a7a02fa0f89990d2653`
- `npm ci`
- `npm run release:gate:sandbox` progressed through build, typecheck, perf, memory, GuardBench, publication verification, and Python release checks; original failure was `EPERM: mkdtemp 'L:\caches\temp\audrey-smoke-XXXXXX'`
- After patch: `npm run smoke:cli` passed with the same bad host `%TEMP%`
- `npm run security:audit` passed, 0 vulnerabilities
- `npm run pack:check` passed

## Risk
- Low. Changes only the smoke-test temp directory selection path; runtime package behavior is unchanged.