### PR TITLE
Fix npm 1.1.0 native dependency publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.14.1
       - run: npm ci
       - run: npm run build
       - run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -221,6 +221,12 @@
   "overrides": {
     "qs": "^6.15.2"
   },
+  "allowScripts": {
+    "better-sqlite3@12.9.0": true,
+    "onnxruntime-node@1.21.0": true,
+    "protobufjs@7.6.5": true,
+    "sharp@0.34.5": true
+  },
   "directories": {
     "example": "examples",
     "test": "tests"


### PR DESCRIPTION
## What changed

- pin the v1.1 npm publishing job to npm 11.14.1 instead of a floating `npm@latest`
- explicitly approve the four pinned production dependency install scripts required by npm 12's new default policy

## Why

The v1.1.0 release workflow upgraded itself to npm 12.0.0. npm 12 silently withholds unapproved dependency install scripts, so `better-sqlite3` was present but its native binding was never installed. `npm test` then failed before `npm publish`; PyPI completed successfully and npm 1.1.0 remains unpublished.

Pinning npm 11.14.1 lets the immutable v1.1.0 tag use the trusted-publishing path it was built for. The pinned `allowScripts` map makes subsequent Audrey development and releases explicit and compatible with npm 12 without enabling arbitrary lifecycle scripts.

## Verification

- clean Node 24.18 + npm 11.14.1 install loaded better-sqlite3, ONNX Runtime, protobufjs, and sharp
- clean Node 24.18 + npm 12.0.0 install reported zero unreviewed install scripts and loaded the same native dependencies
- 842 tests passed (13 skipped)
- build, typecheck, ESLint, and Prettier checks passed
- both clean installs reported zero vulnerabilities