### PR TITLE
fix: make guard signals self-extinguishing, project-scoped, and readable

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -2486,10 +2486,20 @@ async function main(): Promise<void> {
         .max(200)
         .optional()
         .describe('Max rows to return (defaults to 20)'),
+      cwd: z
+        .string()
+        .optional()
+        .describe('Scope failures to the project containing this directory'),
+      include_resolved: z
+        .boolean()
+        .optional()
+        .describe('Include failure streaks already resolved by a later success (default false)'),
     },
-    async ({ since, limit }) => {
+    async ({ since, limit, cwd, include_resolved }) => {
       try {
-        return toolResult(audrey.recentFailures({ since, limit }));
+        return toolResult(
+          audrey.recentFailures({ since, limit, cwd, includeResolved: include_resolved }),
+        );
       } catch (err) {
         return toolError(err);
       }
@@ -2541,6 +2551,10 @@ async function main(): Promise<void> {
         .describe(
           'agent restricts memory recall to this MCP server agent identity. shared searches the whole store. Defaults to agent.',
         ),
+      cwd: z
+        .string()
+        .optional()
+        .describe('Scope tool-failure risks to the project containing this directory.'),
     },
     async ({
       query,
@@ -2551,6 +2565,7 @@ async function main(): Promise<void> {
       include_risks,
       include_contradictions,
       scope,
+      cwd,
     }) => {
       try {
         const capsule = await audrey.capsule(query, {
@@ -2560,6 +2575,7 @@ async function main(): Promise<void> {
           recentChangeWindowHours: recent_change_window_hours,
           includeRisks: include_risks,
           includeContradictions: include_contradictions,
+          cwd,
           recall: { scope: scope ?? 'agent' },
         });
         return toolResult(capsule);

--- a/src/audrey.ts
+++ b/src/audrey.ts
@@ -1312,12 +1312,16 @@ export class Audrey extends EventEmitter {
       limit?: number;
       actorAgent?: string;
       scope?: RecallOptions['scope'];
+      cwd?: string;
+      includeResolved?: boolean;
     } = {},
   ): FailurePattern[] {
     const scope = resolveMemoryScope(options.scope, 'agent');
     return recentFailures(this.db, {
       since: options.since,
       limit: options.limit,
+      cwd: options.cwd,
+      includeResolved: options.includeResolved,
       ...(scope === 'agent' ? { actorAgent: requireAgent(options.actorAgent, this.agent) } : {}),
     });
   }

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -1,9 +1,8 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { existsSync, realpathSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
 import type { Audrey } from './audrey.js';
 import type { MemoryCapsule, CapsuleEntry } from './capsule.js';
 import { MemoryController, type ControllerGuardResult } from './controller.js';
+import { projectNamespace } from './project.js';
 import { redact } from './redact.js';
 
 export type AutopilotHost = 'claude-code' | 'codex';
@@ -90,31 +89,6 @@ function quotedMemoryText(value: string, maxChars = 800): string {
 
 function sha256(value: string): string {
   return createHash('sha256').update(value).digest('hex');
-}
-
-function canonicalDirectory(value: string): string {
-  const absolute = resolve(value);
-  try {
-    return realpathSync(absolute).replace(/^\\\\\?\\/, '');
-  } catch {
-    return absolute;
-  }
-}
-
-function projectRoot(cwd: string): string {
-  let current = canonicalDirectory(cwd);
-  while (true) {
-    if (existsSync(join(current, '.git'))) return current;
-    const parent = dirname(current);
-    if (parent === current) return canonicalDirectory(cwd);
-    current = parent;
-  }
-}
-
-function projectNamespace(cwd: string): string {
-  const root = projectRoot(cwd).replace(/\\/g, '/');
-  const stableRoot = process.platform === 'win32' ? root.toLowerCase() : root;
-  return `project:${sha256(stableRoot)}`;
 }
 
 function payloadProjectNamespace(payload: JsonRecord): string {
@@ -678,10 +652,14 @@ async function contextForHook(
     metadata: { autopilot: true, host: options.host },
   });
   const namespace = payloadProjectNamespace(payload);
+  // cwd scopes tool-failure risks even under scope: 'shared' — semantic
+  // knowledge is worth sharing across projects, but a failure streak in
+  // another repo says nothing about this one.
   const unscopedCapsule = await audrey.capsule(contextQuery(event, payload), {
     budgetChars: options.contextBudgetChars ?? 3200,
     mode: 'conservative',
     scope: options.scope ?? 'agent',
+    cwd: text(payload.cwd) ?? process.cwd(),
     recall: {
       scope: options.scope ?? 'agent',
       context: {

--- a/src/capsule.ts
+++ b/src/capsule.ts
@@ -20,6 +20,7 @@ import type Database from 'better-sqlite3';
 import type { Audrey } from './audrey.js';
 import type { RecallError, RecallResult, RecallOptions, MemoryType, MemoryState } from './types.js';
 import { recentFailures, type FailurePattern } from './events.js';
+import { projectNamespace } from './project.js';
 import { requireAgent, resolveMemoryScope } from './utils.js';
 
 export type CapsuleMode = 'balanced' | 'conservative' | 'aggressive';
@@ -34,6 +35,8 @@ export interface CapsuleOptions {
   includeRisks?: boolean;
   includeContradictions?: boolean;
   recall?: RecallOptions;
+  /** Scope tool-failure risks to the project containing this directory. */
+  cwd?: string;
 }
 
 export type CapsuleEntryType =
@@ -80,7 +83,14 @@ export interface MemoryCapsule {
 
 const MUST_FOLLOW_TAGS = new Set(['must-follow', 'must', 'required', 'never', 'always', 'policy']);
 const PREFERENCE_TAGS = new Set(['preference', 'prefers', 'user-preference']);
-const RISK_TAGS = new Set(['risk', 'warning', 'failure', 'failure-prevention', 'danger']);
+const RISK_TAGS = new Set([
+  'risk',
+  'warning',
+  'failure',
+  'tool-failure',
+  'failure-prevention',
+  'danger',
+]);
 const PROCEDURE_TAGS = new Set(['procedure', 'playbook', 'howto', 'workflow']);
 
 const SECTION_PRIORITY: readonly (keyof MemoryCapsule['sections'])[] = [
@@ -101,6 +111,7 @@ interface EpisodeTagRow {
   created_at: string;
   private: number;
   agent?: string | null;
+  context: string | null;
 }
 
 interface SemanticTagRow {
@@ -186,11 +197,19 @@ function buildRecallEntry(
   };
 }
 
+function shortenError(value: string, max = 240): string {
+  const text = value.replace(/\s+/g, ' ').trim();
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1)}…`;
+}
+
 function buildFailureEntry(f: FailurePattern, reason: string): CapsuleEntry {
   const toolLabel = f.tool_name || 'unknown tool';
   const idLabel = f.tool_name || 'unknown';
+  // The full error lives in the memory_events row; the capsule only needs
+  // enough to recognize the failure, not the whole stack trace.
   const summary = f.last_error_summary
-    ? `${toolLabel} failed ${f.failure_count}x recently — last error: ${f.last_error_summary}`
+    ? `${toolLabel} failed ${f.failure_count}x recently — last error: ${shortenError(f.last_error_summary)}`
     : `${toolLabel} failed ${f.failure_count}x recently`;
   return {
     memory_id: `failure:${idLabel}:${f.last_failed_at}`,
@@ -219,8 +238,24 @@ function buildContradictionEntry(row: ContradictionRow, reason: string): Capsule
 
 function loadEpisodeEnrichment(db: Database.Database, id: string): EpisodeTagRow | undefined {
   return db
-    .prepare(`SELECT id, tags, source, created_at, private, agent FROM episodes WHERE id = ?`)
+    .prepare(
+      `SELECT id, tags, source, created_at, private, agent, context FROM episodes WHERE id = ?`,
+    )
     .get(id) as EpisodeTagRow | undefined;
+}
+
+function episodeProjectNamespace(row: EpisodeTagRow | undefined): string | undefined {
+  if (!row?.context) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(row.context);
+    const namespace =
+      parsed && typeof parsed === 'object'
+        ? (parsed as Record<string, unknown>)['projectNamespace']
+        : undefined;
+    return typeof namespace === 'string' && namespace ? namespace : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function loadSemanticEnrichment(db: Database.Database, id: string): SemanticTagRow | undefined {
@@ -380,6 +415,8 @@ export async function buildCapsule(
 
   const db = audrey.db;
 
+  const cwdNamespace = options.cwd ? projectNamespace(options.cwd) : undefined;
+
   for (const result of results) {
     let tags: string[] = [];
     let evidence: string[] = [];
@@ -389,6 +426,13 @@ export async function buildCapsule(
       const row = loadEpisodeEnrichment(db, result.id);
       tags = parseTags(row?.tags);
       scope = row?.agent ? `agent:${row.agent}` : undefined;
+      // Tool-failure episodes are project-local operational records (their
+      // durable lessons travel via consolidation instead). A failure recorded
+      // in another project is noise here, even under shared scope.
+      if (cwdNamespace && tags.some(tag => tag.toLowerCase() === 'tool-failure')) {
+        const episodeNamespace = episodeProjectNamespace(row);
+        if (episodeNamespace && episodeNamespace !== cwdNamespace) continue;
+      }
     } else if (result.type === 'semantic') {
       const row = loadSemanticEnrichment(db, result.id);
       evidence = parseEvidence(row?.evidence_episode_ids);
@@ -434,6 +478,7 @@ export async function buildCapsule(
     const failures = recentFailures(db, {
       since: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
       limit: 5,
+      ...(options.cwd ? { cwd: options.cwd } : {}),
       ...(memoryScope === 'agent' ? { actorAgent: memoryAgent } : {}),
     });
     for (const failure of failures) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,6 +4,7 @@
  */
 
 import Database from 'better-sqlite3';
+import { namespaceMatcher } from './project.js';
 import { generateId } from './ulid.js';
 import { requireAgent } from './utils.js';
 
@@ -211,48 +212,123 @@ export interface FailurePattern {
   failure_count: number;
   last_error_summary: string | null;
   last_failed_at: string;
+  last_succeeded_at: string | null;
+}
+
+export interface RecentFailureOptions {
+  since?: string;
+  limit?: number;
+  actorAgent?: string;
+  /**
+   * Scope failure patterns to the project containing this directory. Events
+   * recorded without a cwd are still included — they cannot be proven foreign.
+   */
+  cwd?: string;
+  /**
+   * By default a failure pattern is extinguished once the same tool succeeds
+   * after it (within the same scope): the streak is over, so the warning would
+   * be stale noise. Pass true to see resolved patterns too (diagnostics).
+   */
+  includeResolved?: boolean;
+}
+
+function matchingCwds(
+  db: Database.Database,
+  cwd: string,
+  since: string,
+  actorAgent: string | undefined,
+): string[] {
+  const rows = db
+    .prepare(
+      `
+    SELECT DISTINCT cwd FROM memory_events
+    WHERE cwd IS NOT NULL
+      AND tool_name IS NOT NULL
+      AND outcome IN ('failed', 'succeeded')
+      AND created_at >= @since
+      ${actorAgent ? 'AND actor_agent = @actorAgent' : ''}
+  `,
+    )
+    .all({ since, ...(actorAgent ? { actorAgent } : {}) }) as Array<{ cwd: string }>;
+  const matches = namespaceMatcher(cwd);
+  return rows.map(row => row.cwd).filter(matches);
 }
 
 /**
- * Tools that have failed recently, most recent first. Feeds PreToolUse
+ * Tools with an unresolved failure streak, most recent first. Feeds PreToolUse
  * preflight warnings: "this command failed last time — here's what fixed it."
+ *
+ * failure_count counts failures since the tool's last success in scope
+ * (extinction: disconfirming evidence retires the warning), not raw failures
+ * in the window.
  */
 export function recentFailures(
   db: Database.Database,
-  options: { since?: string; limit?: number; actorAgent?: string } = {},
+  options: RecentFailureOptions = {},
 ): FailurePattern[] {
   const since = options.since ?? new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
   const limit = Math.max(1, Math.min(options.limit ?? 20, 200));
   const actorAgent =
     options.actorAgent === undefined ? undefined : requireAgent(options.actorAgent);
-  const actorClause = actorAgent ? 'AND actor_agent = @actorAgent' : '';
-  const nestedActorClause = actorAgent ? 'AND e2.actor_agent = @actorAgent' : '';
+
+  const params: Record<string, unknown> = { since };
+  if (actorAgent) params.actorAgent = actorAgent;
+
+  let cwdNames: string[] | undefined;
+  if (options.cwd) {
+    cwdNames = matchingCwds(db, options.cwd, since, actorAgent).map((value, index) => {
+      params[`cwd${index}`] = value;
+      return `@cwd${index}`;
+    });
+  }
+
+  const scopedClauses = (alias: string) => {
+    const clauses = [actorAgent ? `AND ${alias}.actor_agent = @actorAgent` : ''];
+    if (cwdNames !== undefined) {
+      clauses.push(
+        cwdNames.length > 0
+          ? `AND (${alias}.cwd IS NULL OR ${alias}.cwd IN (${cwdNames.join(', ')}))`
+          : `AND ${alias}.cwd IS NULL`,
+      );
+    }
+    return clauses.filter(Boolean).join('\n               ');
+  };
+
+  const lastSuccessSubquery = `
+             SELECT MAX(s.created_at) FROM memory_events s
+             WHERE s.tool_name = e1.tool_name
+               AND s.outcome = 'succeeded'
+               AND s.created_at >= @since
+               ${scopedClauses('s')}
+  `;
 
   return db
     .prepare(
       `
-    SELECT tool_name,
+    SELECT e1.tool_name,
            COUNT(*) AS failure_count,
-           MAX(created_at) AS last_failed_at,
+           MAX(e1.created_at) AS last_failed_at,
            (
              SELECT error_summary FROM memory_events e2
              WHERE e2.tool_name = e1.tool_name
                AND e2.outcome = 'failed'
                AND e2.created_at >= @since
-               ${nestedActorClause}
+               ${scopedClauses('e2')}
              ORDER BY e2.created_at DESC LIMIT 1
-           ) AS last_error_summary
+           ) AS last_error_summary,
+           (${lastSuccessSubquery}) AS last_succeeded_at
     FROM memory_events e1
-    WHERE outcome = 'failed'
-      AND tool_name IS NOT NULL
-      AND created_at >= @since
-      ${actorClause}
-    GROUP BY tool_name
+    WHERE e1.outcome = 'failed'
+      AND e1.tool_name IS NOT NULL
+      AND e1.created_at >= @since
+      ${scopedClauses('e1')}
+      ${options.includeResolved ? '' : `AND e1.created_at > COALESCE((${lastSuccessSubquery}), '')`}
+    GROUP BY e1.tool_name
     ORDER BY last_failed_at DESC
     LIMIT ${limit}
   `,
     )
-    .all({ since, ...(actorAgent ? { actorAgent } : {}) }) as FailurePattern[];
+    .all(params) as FailurePattern[];
 }
 
 export function deleteEventsBefore(db: Database.Database, cutoffIso: string): number {

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -118,7 +118,17 @@ function warningFromEntry(
 function toolFromFailureEntry(entry: CapsuleEntry): string | undefined {
   const fromId = entry.memory_id.match(/^failure:([^:]+):/)?.[1];
   if (fromId) return fromId;
-  return entry.content.match(/^([^\s]+) failed\b/)?.[1];
+  return (
+    entry.content.match(/^Tool failure: ([^\s]+) failed\b/)?.[1] ??
+    entry.content.match(/^([^\s]+) failed\b/)?.[1]
+  );
+}
+
+function isToolFailureEntry(entry: CapsuleEntry): boolean {
+  return (
+    entry.memory_type === 'tool_failure' ||
+    Boolean(entry.tags?.some(tag => tag.toLowerCase() === 'tool-failure'))
+  );
 }
 
 function addWarning(
@@ -215,6 +225,7 @@ export async function buildPreflight(
     includeContradictions: true,
     scope,
     agent,
+    ...(options.cwd ? { cwd: options.cwd } : {}),
     recall: { scope, agent },
   });
 
@@ -285,6 +296,7 @@ export async function buildPreflight(
     limit: 20,
     scope,
     actorAgent: agent,
+    ...(options.cwd ? { cwd: options.cwd } : {}),
   });
   const matchingFailures: FailurePattern[] = [];
   for (const failure of recentFailures) {
@@ -312,7 +324,8 @@ export async function buildPreflight(
   }
 
   for (const entry of capsule.sections.risks) {
-    if (entry.memory_type === 'tool_failure') {
+    const toolFailure = isToolFailureEntry(entry);
+    if (toolFailure) {
       const failedTool = toolFromFailureEntry(entry);
       if (!matchesToolOrAction(action, options.tool, failedTool)) continue;
     }
@@ -320,8 +333,8 @@ export async function buildPreflight(
       warnings,
       seen,
       warningFromEntry(
-        entry.memory_type === 'tool_failure' ? 'recent_failure' : 'risk',
-        entry.memory_type === 'tool_failure' ? 'medium' : 'high',
+        toolFailure ? 'recent_failure' : 'risk',
+        toolFailure ? 'medium' : 'high',
         entry,
         'Mitigate this remembered risk before proceeding.',
       ),

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,0 +1,58 @@
+/**
+ * Project identity for scoping memory signals.
+ *
+ * A "project" is the git repository containing a working directory (falling
+ * back to the directory itself when no .git is found). Namespaces hash the
+ * canonical root so paths never leak into stored context values.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function canonicalDirectory(value: string): string {
+  const absolute = resolve(value);
+  try {
+    return realpathSync(absolute).replace(/^\\\\\?\\/, '');
+  } catch {
+    return absolute;
+  }
+}
+
+export function projectRoot(cwd: string): string {
+  let current = canonicalDirectory(cwd);
+  while (true) {
+    if (existsSync(join(current, '.git'))) return current;
+    const parent = dirname(current);
+    if (parent === current) return canonicalDirectory(cwd);
+    current = parent;
+  }
+}
+
+export function projectNamespace(cwd: string): string {
+  const root = projectRoot(cwd).replace(/\\/g, '/');
+  const stableRoot = process.platform === 'win32' ? root.toLowerCase() : root;
+  return `project:${sha256(stableRoot)}`;
+}
+
+/**
+ * Namespace lookups walk the filesystem (realpath + .git discovery), so batch
+ * callers should reuse one cache per operation instead of recomputing for
+ * every event row.
+ */
+export function namespaceMatcher(cwd: string): (candidate: string) => boolean {
+  const target = projectNamespace(cwd);
+  const cache = new Map<string, boolean>();
+  return (candidate: string) => {
+    let match = cache.get(candidate);
+    if (match === undefined) {
+      match = projectNamespace(candidate) === target;
+      cache.set(candidate, match);
+    }
+    return match;
+  };
+}

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -216,8 +216,23 @@ function shannonEntropy(value: string): number {
   return entropy;
 }
 
+/**
+ * Snake_case / kebab-case / dotted identifiers (MCP tool names, env vars,
+ * long function names) can clear the length and entropy bars, but a real
+ * base64/base64url secret essentially never splits on separators into three
+ * or more purely alphabetic runs. Redacting identifiers destroys the guard
+ * signals that reference them ("[REDACTED] failed 2x recently"), so exempt
+ * this shape explicitly.
+ */
+function looksLikeWordIdentifier(value: string): boolean {
+  const segments = value.split(/[_\-.]+/).filter(Boolean);
+  if (segments.length < 3) return false;
+  return segments.every(segment => /^[A-Za-z]+$/.test(segment) && segment.length <= 20);
+}
+
 function looksLikeHighEntropySecret(value: string): boolean {
   if (value.length < 32) return false;
+  if (looksLikeWordIdentifier(value)) return false;
   const classes = [
     /[a-z]/.test(value),
     /[A-Z]/.test(value),

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -82,6 +82,13 @@ describe('memory_events CRUD', () => {
 
   it('recentFailures groups failures by tool with most recent error', () => {
     insertEvent(db, {
+      eventType: 'PostToolUse',
+      source: 'tool-trace',
+      toolName: 'Bash',
+      outcome: 'succeeded',
+      createdAt: '2026-04-19T12:00:00Z',
+    });
+    insertEvent(db, {
       eventType: 'PostToolUseFailure',
       source: 'tool-trace',
       toolName: 'Bash',
@@ -105,20 +112,130 @@ describe('memory_events CRUD', () => {
       errorSummary: 'edit failed',
       createdAt: '2026-04-21T10:00:00Z',
     });
-    insertEvent(db, {
-      eventType: 'PostToolUse',
-      source: 'tool-trace',
-      toolName: 'Bash',
-      outcome: 'succeeded',
-      createdAt: '2026-04-22T11:00:00Z',
-    });
 
     const failures = recentFailures(db, { since: '2026-04-19T00:00:00Z' });
     expect(failures).toHaveLength(2);
     const bash = failures.find(f => f.tool_name === 'Bash');
     expect(bash?.failure_count).toBe(2);
     expect(bash?.last_error_summary).toBe('newer error');
+    expect(bash?.last_succeeded_at).toBe('2026-04-19T12:00:00Z');
     expect(failures[0].tool_name).toBe('Bash'); // most recent first
+  });
+
+  it('recentFailures extinguishes a streak once the tool succeeds after it', () => {
+    insertEvent(db, {
+      eventType: 'PostToolUseFailure',
+      source: 'tool-trace',
+      toolName: 'Bash',
+      outcome: 'failed',
+      errorSummary: 'lint loop',
+      createdAt: '2026-04-20T10:00:00Z',
+    });
+    insertEvent(db, {
+      eventType: 'PostToolUse',
+      source: 'tool-trace',
+      toolName: 'Bash',
+      outcome: 'succeeded',
+      createdAt: '2026-04-20T11:00:00Z',
+    });
+
+    expect(recentFailures(db, { since: '2026-04-19T00:00:00Z' })).toHaveLength(0);
+
+    const resolved = recentFailures(db, {
+      since: '2026-04-19T00:00:00Z',
+      includeResolved: true,
+    });
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].last_succeeded_at).toBe('2026-04-20T11:00:00Z');
+  });
+
+  it('recentFailures counts only failures after the most recent success', () => {
+    const events = [
+      ['failed', '2026-04-20T08:00:00Z'],
+      ['succeeded', '2026-04-20T09:00:00Z'],
+      ['failed', '2026-04-20T10:00:00Z'],
+      ['failed', '2026-04-20T11:00:00Z'],
+    ];
+    for (const [outcome, createdAt] of events) {
+      insertEvent(db, {
+        eventType: outcome === 'failed' ? 'PostToolUseFailure' : 'PostToolUse',
+        source: 'tool-trace',
+        toolName: 'Bash',
+        outcome,
+        errorSummary: outcome === 'failed' ? `error at ${createdAt}` : undefined,
+        createdAt,
+      });
+    }
+
+    const failures = recentFailures(db, { since: '2026-04-19T00:00:00Z' });
+    expect(failures).toHaveLength(1);
+    expect(failures[0].failure_count).toBe(2);
+    expect(failures[0].last_succeeded_at).toBe('2026-04-20T09:00:00Z');
+  });
+
+  it('recentFailures scopes to the project when cwd is provided', () => {
+    // Distinct .git markers keep the fixtures from resolving up to this
+    // repository's own project root.
+    const projectA = `${TEST_DIR}/project-a`;
+    const projectB = `${TEST_DIR}/project-b`;
+    for (const dir of [projectA, projectB]) mkdirSync(`${dir}/.git`, { recursive: true });
+
+    insertEvent(db, {
+      eventType: 'PostToolUseFailure',
+      source: 'tool-trace',
+      toolName: 'Bash',
+      outcome: 'failed',
+      errorSummary: 'failure in project A',
+      cwd: projectA,
+      createdAt: '2026-04-20T10:00:00Z',
+    });
+    insertEvent(db, {
+      eventType: 'PostToolUseFailure',
+      source: 'tool-trace',
+      toolName: 'Edit',
+      outcome: 'failed',
+      errorSummary: 'failure without cwd',
+      createdAt: '2026-04-20T10:30:00Z',
+    });
+
+    const inB = recentFailures(db, { since: '2026-04-19T00:00:00Z', cwd: projectB });
+    // Project A's Bash failure is foreign; the cwd-less Edit failure cannot
+    // be proven foreign and stays.
+    expect(inB.map(f => f.tool_name)).toEqual(['Edit']);
+
+    const inA = recentFailures(db, { since: '2026-04-19T00:00:00Z', cwd: projectA });
+    expect(inA.map(f => f.tool_name).sort()).toEqual(['Bash', 'Edit']);
+  });
+
+  it('recentFailures does not let a success in another project extinguish a local streak', () => {
+    const projectA = `${TEST_DIR}/project-a`;
+    const projectB = `${TEST_DIR}/project-b`;
+    for (const dir of [projectA, projectB]) mkdirSync(`${dir}/.git`, { recursive: true });
+
+    insertEvent(db, {
+      eventType: 'PostToolUseFailure',
+      source: 'tool-trace',
+      toolName: 'Bash',
+      outcome: 'failed',
+      errorSummary: 'still broken here',
+      cwd: projectA,
+      createdAt: '2026-04-20T10:00:00Z',
+    });
+    insertEvent(db, {
+      eventType: 'PostToolUse',
+      source: 'tool-trace',
+      toolName: 'Bash',
+      outcome: 'succeeded',
+      cwd: projectB,
+      createdAt: '2026-04-20T11:00:00Z',
+    });
+
+    const inA = recentFailures(db, { since: '2026-04-19T00:00:00Z', cwd: projectA });
+    expect(inA).toHaveLength(1);
+    expect(inA[0].last_succeeded_at).toBeNull();
+
+    // Without a cwd filter the cross-project success does resolve the streak.
+    expect(recentFailures(db, { since: '2026-04-19T00:00:00Z' })).toHaveLength(0);
   });
 
   it('deleteEventsBefore removes events older than cutoff', () => {

--- a/tests/redact.test.js
+++ b/tests/redact.test.js
@@ -135,6 +135,28 @@ describe('redact', () => {
     expect(result.text).toContain('[REDACTED:high_entropy_secret');
   });
 
+  it('does not redact long snake_case tool identifiers', () => {
+    const tools = [
+      'mcp__plugin_playwright_playwright__browser_navigate',
+      'mcp__plugin_playwright_playwright__browser_take_screenshot',
+      'mcp__audrey-memory__memory_observe_tool',
+      'AUDREY_AUTOPILOT_MAINTENANCE_INTERVAL_HOURS',
+    ];
+    for (const tool of tools) {
+      const result = redact(`${tool} failed 2x recently`);
+      expect(result.state, tool).toBe('clean');
+      expect(result.text, tool).toContain(tool);
+    }
+  });
+
+  it('still redacts secrets that contain separators', () => {
+    // base64url-style token with underscores/hyphens but digit-bearing segments
+    const token = 'q9V1nZ4L_kP7sD2fGh8-JmR3tY6uW0xAbC5eF1gH';
+    const result = redact(`leaked ${token} in output`);
+    expect(result.redactions.find(r => r.class === 'high_entropy_secret')?.count).toBe(1);
+    expect(result.text).not.toContain(token);
+  });
+
   it('redactJson walks nested structures', () => {
     const result = redactJson({
       config: { password: 'hunter2abcdef' },

--- a/tests/tool-trace.test.js
+++ b/tests/tool-trace.test.js
@@ -164,7 +164,7 @@ describe('observeTool — end-to-end action trace memory', () => {
     expect(event.file_fingerprints).toBeNull();
   });
 
-  it('recentFailures surfaces previously-failed tools', () => {
+  it('recentFailures surfaces unresolved failures and extinguishes resolved ones', () => {
     audrey.observeTool({
       event: 'PostToolUseFailure',
       tool: 'Bash',
@@ -179,11 +179,18 @@ describe('observeTool — end-to-end action trace memory', () => {
       errorSummary: 'file locked',
     });
 
+    // Bash succeeded after its failure, so the streak is resolved and no
+    // longer warned about; Edit's failure is still live.
     const failures = audrey.recentFailures();
-    expect(failures.map(f => f.tool_name).sort()).toEqual(['Bash', 'Edit']);
-    const bash = failures.find(f => f.tool_name === 'Bash');
-    expect(bash?.failure_count).toBe(1);
+    expect(failures.map(f => f.tool_name)).toEqual(['Edit']);
+    expect(failures[0].failure_count).toBe(1);
+    expect(failures[0].last_error_summary).toContain('file locked');
+
+    const resolved = audrey.recentFailures({ includeResolved: true });
+    expect(resolved.map(f => f.tool_name).sort()).toEqual(['Bash', 'Edit']);
+    const bash = resolved.find(f => f.tool_name === 'Bash');
     expect(bash?.last_error_summary).toContain('missing env var');
+    expect(bash?.last_succeeded_at).not.toBeNull();
   });
 
   it('listEvents filters by toolName and limit', () => {


### PR DESCRIPTION
## Summary
Three defects found by dogfooding Audrey's own autopilot packets during a live session, all destroying the signal-to-noise ratio of injected memory:

1. **Redaction ate MCP tool identifiers.** The `high_entropy_secret` rule flagged snake_case names like `mcp__plugin_playwright_playwright__browser_navigate`, so guard warnings rendered as `[REDACTED:high_entropy_secret:gate] failed 2x recently` — unactionable. Word-identifier shapes (3+ separator-delimited alphabetic segments) are now exempt; secrets with digit-bearing segments still redact.

2. **Failure streaks never extinguished.** `recentFailures()` counted raw failures in a 7-day window, so a 72x Bash lint loop in one repo nagged every Bash call at 0.95 confidence for a week, even after hundreds of subsequent successes. `failure_count` now counts failures **since the tool's last success in scope** — a success retires the warning. This is extinction by disconfirming evidence, the complement to time-based decay. `include_resolved=true` keeps the raw diagnostic view.

3. **Failure signals leaked across projects.** Tool failures are project-local operational records, but they warned globally — and learned tool-failure *episodes* miscategorized into `project_facts` because `RISK_TAGS` lacked the `tool-failure` tag that `learnFailure` actually writes. `recentFailures`/`capsule`/`preflight` now accept `cwd` and scope failure signals to the containing project; autopilot passes `cwd` even under `scope: shared`, so shared semantic knowledge still travels while foreign failure noise does not.

New `src/project.ts` hosts `projectRoot`/`projectNamespace` (shared by autopilot + events). MCP tools `memory_recent_failures` and `memory_capsule` gain optional `cwd` (+ `include_resolved`).

## Verification
- `npm run build`, `typecheck`, `lint`, `format:check` clean
- Full suite: 848 passed, 13 skipped, 0 failed (7 new tests: extinction, consecutive-failure counting, project scoping, cross-project success isolation, identifier redaction exemption)
- **Live before/after**: piped a real `UserPromptSubmit` payload through the rebuilt hook against the production store — the packet previously led with a foreign 900-char lint-error wall, redacted tool names, and stale keylit failure episodes at confidence 1.00; it now injects only project-relevant preferences, facts, and procedures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)