### PR TITLE
fix: make MCP Registry publish re-runnable and fit description limit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,11 @@ on:
         required: true
         default: true
         type: boolean
+      publish_mcp:
+        description: Publish server metadata to the MCP Registry
+        required: true
+        default: true
+        type: boolean
 
 env:
   RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
@@ -117,16 +122,26 @@ jobs:
     needs:
       - validate-release
       - publish-npm
-    if: github.event_name == 'release' || inputs.publish_npm
+    # Registry publishes are metadata-only and must be re-runnable after a
+    # rejected submission without republishing npm (which is immutable), so a
+    # dispatch with publish_mcp can run even when publish-npm is skipped.
+    if: >-
+      !cancelled() && needs.validate-release.result == 'success' &&
+      ((github.event_name == 'release' && needs.publish-npm.result == 'success') ||
+       (github.event_name == 'workflow_dispatch' && inputs.publish_mcp &&
+        contains(fromJSON('["success", "skipped"]'), needs.publish-npm.result)))
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write # GitHub OIDC auth claims the io.github.evilander/* namespace
 
     steps:
+      # Release events publish the tagged server.json; dispatches publish the
+      # dispatched ref's server.json so metadata fixes don't require retagging.
+      # The version is always stamped from the validated release tag.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-release.outputs.tag }}
+          ref: ${{ github.event_name == 'release' && needs.validate-release.outputs.tag || github.ref }}
 
       - name: Install mcp-publisher
         run: |

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.evilander/audrey",
-  "description": "Local-first biological memory for coding agents: episodic encoding, consolidation into semantic and procedural knowledge, evidence-backed recall, and pre-action Guard checks over SQLite.",
+  "description": "Local-first biological memory for coding agents: recall, consolidation, and pre-action Guard checks.",
   "repository": {
     "url": "https://github.com/Evilander/Audrey",
     "source": "github"


### PR DESCRIPTION
## Summary
The v1.1.2 pipeline published npm + PyPI cleanly, but the new MCP Registry job was rejected with **422: `body.description` expected length ≤ 100** (ours was 187). Two fixes:

1. `server.json` description shortened to exactly 100 chars.
2. The registry job is now **re-runnable without republishing npm**: a `publish_mcp` dispatch input runs it standalone (npm/PyPI skipped), checking out the dispatched ref's `server.json` (so metadata fixes don't require retagging) while still stamping the version validated against the release tag. Release events keep tagged checkout and the npm-success ordering.

## Verification
- npm `audrey@1.1.2` is already live with the `mcpName` ownership field the registry validates against.
- After merge: `gh workflow run publish.yml -f tag=v1.1.2 -f publish_npm=false -f publish_pypi=false -f publish_mcp=true` completes the registry listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)